### PR TITLE
Fix stale logged-out cache in header after sign-in

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -148,7 +148,7 @@ const prefix = lang === 'tr' ? '/tr' : '';
     }
 
     var cached = getCached();
-    (cached ? Promise.resolve(cached) : fetch('/api/me').then(function(r) { return r.json(); }).then(function(d) { setCache(d); return d; }))
+    (cached ? Promise.resolve(cached) : fetch('/api/me').then(function(r) { return r.json(); }).then(function(d) { if (d.user) { setCache(d); } return d; }))
       .then(function (data) {
         var joinBtn = document.getElementById('joinBtn');
         if (joinBtn && (!data.user || !data.user.is_member)) {


### PR DESCRIPTION
The header's client-side /api/me cache (sessionStorage, 5 min TTL) was caching the anonymous result too. If you loaded any page before signing in, that cached {user: null} snapshot would mask a freshly-created, valid session cookie for up to 5 minutes after login — you'd see the profile page correctly (server-rendered from the cookie) but the header would still show 'Sign In' on other pages.

Fix: only cache the positive (logged-in) result. Checking /api/me for an anonymous visitor is cheap, so there's no downside to always re-checking it.