### PR TITLE
Fix symposium-website Cloudflare Pages build failure

### DIFF
--- a/symposium_website/wrangler.toml
+++ b/symposium_website/wrangler.toml
@@ -1,0 +1,2 @@
+name = "rsg-symposium"
+pages_build_output_dir = "dist"


### PR DESCRIPTION
The symposium-website Pages project (root directory: symposium_website) had no wrangler.toml of its own, so Cloudflare's config auto-detection walked up and picked up the repo-root wrangler.toml — which belongs to the main 'website' project and declares `pages_build_output_dir = "dist"` relative to repo root. Resolved relative to symposium_website's root directory, that becomes `../dist`, which escapes the project's root and fails with 'build output directory is outside of the repository'.

Adding a scoped wrangler.toml inside symposium_website/ with the correct relative path fixes this without touching the main website project's config.