### PR TITLE
Wire up Growth rank and Pipeline achievement badges

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -72,9 +72,54 @@ CREATE TABLE IF NOT EXISTS progress (
   PRIMARY KEY (user_id, resource_id)
 );
 
+-- Growth rank: Tohum/Seed -> Filiz/Sprout -> Fidan/Sapling -> Çınar/Legacy Tree.
+-- Insert-only log, never updated or deleted. A user's current rank is always
+-- the highest rank_ordinal ever recorded for them (see idx below) -- this is
+-- what makes rank a high-water mark: a later drop in activity can only add a
+-- lower-ordinal row, which never changes the MAX(), so rank can't regress.
+-- The score behind each entry is computed in application code from a blend
+-- of learning-path progress, event/project participation, and community
+-- contribution; the weighting between those is intentionally not encoded
+-- here so it stays tunable without a schema change.
+CREATE TABLE IF NOT EXISTS rank_history (
+  id           TEXT PRIMARY KEY,
+  user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  rank         TEXT NOT NULL CHECK (rank IN ('seed', 'sprout', 'sapling', 'legacy_tree')),
+  rank_ordinal INTEGER NOT NULL CHECK (rank_ordinal BETWEEN 1 AND 4),
+  reason       TEXT,
+  computed_at  INTEGER NOT NULL
+);
+
+-- Pipeline: rare, unordered specialty badges for demonstrated bioinformatics
+-- skills. Independent of Growth rank -- earning one has no bearing on rank,
+-- and they aren't earned in any particular sequence. Catalog is meant to
+-- grow (RNA-seq, metagenomics, phylogenetics, ...) without implying an order.
+CREATE TABLE IF NOT EXISTS achievement_badges (
+  code        TEXT PRIMARY KEY,
+  name_en     TEXT NOT NULL,
+  name_tr     TEXT NOT NULL,
+  description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS user_achievement_badges (
+  user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  badge_code TEXT NOT NULL REFERENCES achievement_badges(code),
+  awarded_at INTEGER NOT NULL,
+  awarded_by TEXT REFERENCES users(id),
+  PRIMARY KEY (user_id, badge_code)
+);
+
+INSERT OR IGNORE INTO achievement_badges (code, name_en, name_tr, description) VALUES
+  ('variant_analysis', 'Variant Analysis', 'Varyant Analizi', 'Identifying and interpreting variants from aligned sequencing data.'),
+  ('read_qc',          'Read QC',          'Okuma QC',        'Assessing and cleaning raw sequencing reads before downstream analysis.'),
+  ('read_alignment',   'Read Alignment',   'Okuma Hizalama',  'Mapping sequencing reads to a reference.'),
+  ('genome_assembly',  'Genome Assembly',  'Genom Montajı',   'Assembling a genome from sequencing reads without a reference.');
+
 -- Indexes for common queries
 CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);
 CREATE INDEX IF NOT EXISTS idx_profiles_username ON profiles(username);
 CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE INDEX IF NOT EXISTS idx_progress_user_id ON progress(user_id);
+CREATE INDEX IF NOT EXISTS idx_rank_history_user_ordinal ON rank_history(user_id, rank_ordinal);
+CREATE INDEX IF NOT EXISTS idx_user_achievement_badges_user_id ON user_achievement_badges(user_id);


### PR DESCRIPTION
Follow-up to #17 (schema). Makes the rank/badge system actually do something:

**Automatic:**
- New members start at Seed (functions/auth/callback.ts, new-user branch).
- Seed -> Sprout -> Sapling auto-promotes based on learning-path completion count (functions/api/progress.ts, on every progress update). Thresholds are a placeholder (3 / 10 completed resources) -- tune freely, not load-bearing on the schema.
- Legacy Tree is deliberately NOT auto-awarded -- it's meant to recognize giving back to the community, and there's no automatic signal for that yet. Admin-only for now.

**Manual (admin panel):**
- New 'Rank' column in /admin: a dropdown per member, calls a new `set_rank` admin action.
- New 'Badges' column: toggle chips for each catalog badge (Variant Analysis, Read QC, Read Alignment, Genome Assembly), calls new `award_badge`/`revoke_badge` actions.
- This is for exceptions/corrections alongside the automatic system, not a replacement for it.

**Shared:**
- functions/_lib/rank.ts centralizes the rank<->ordinal mapping and the read/write helpers (getCurrentRank, awardRank, maybeAutoPromote) so nothing re-implements the high-water-mark logic differently in different places.
- /api/me now returns `rank` and `achievement_badges` for future frontend display (member cards / profile page -- not built yet, this PR is backend + admin only).

**Verified:** `npm run build` succeeds. `npx astro check` adds exactly the same kind of error this repo already has 152 of on main (missing @cloudflare/workers-types, nothing to do with this change) -- confirmed by diffing error count against a clean main checkout.