### PR TITLE
Actually wire up Growth rank and Pipeline achievement badges

### DIFF
--- a/functions/_lib/rank.ts
+++ b/functions/_lib/rank.ts
@@ -1,0 +1,60 @@
+import type { Env } from './auth';
+import { generateId } from './auth';
+
+export const RANK_ORDINALS: Record<string, number> = {
+  seed: 1,
+  sprout: 2,
+  sapling: 3,
+  legacy_tree: 4,
+};
+
+export type Rank = keyof typeof RANK_ORDINALS;
+
+export async function getCurrentRank(
+  userId: string,
+  env: Env
+): Promise<{ rank: string; ordinal: number } | null> {
+  return env.DB.prepare(
+    'SELECT rank, rank_ordinal as ordinal FROM rank_history WHERE user_id = ? ORDER BY rank_ordinal DESC, computed_at DESC LIMIT 1'
+  ).bind(userId).first<{ rank: string; ordinal: number }>();
+}
+
+export async function awardRank(
+  userId: string,
+  rank: Rank,
+  reason: string,
+  env: Env
+): Promise<void> {
+  await env.DB.prepare(
+    'INSERT INTO rank_history (id, user_id, rank, rank_ordinal, reason, computed_at) VALUES (?, ?, ?, ?, ?, ?)'
+  ).bind(generateId(), userId, rank, RANK_ORDINALS[rank], reason, Math.floor(Date.now() / 1000)).run();
+}
+
+/**
+ * Auto-promotes Seed -> Sprout -> Sapling based on learning-path completion
+ * count. Thresholds are a placeholder until event-participation and
+ * community-contribution tracking exist to blend in -- tune freely, they
+ * aren't load-bearing on the schema.
+ *
+ * Legacy Tree is deliberately excluded: it's meant to recognize giving back
+ * to the community, which has no automatic signal yet. Admin-only for now
+ * (see functions/api/admin/users.ts, action "set_rank").
+ */
+export async function maybeAutoPromote(userId: string, env: Env): Promise<void> {
+  const current = await getCurrentRank(userId, env);
+  const currentOrdinal = current?.ordinal ?? RANK_ORDINALS.seed;
+  if (currentOrdinal >= RANK_ORDINALS.sapling) return;
+
+  const completed = await env.DB.prepare(
+    'SELECT COUNT(*) as n FROM progress WHERE user_id = ? AND completed = 1'
+  ).bind(userId).first<{ n: number }>();
+  const n = completed?.n ?? 0;
+
+  let target: Rank | null = null;
+  if (n >= 10) target = 'sapling';
+  else if (n >= 3) target = 'sprout';
+
+  if (target && RANK_ORDINALS[target] > currentOrdinal) {
+    await awardRank(userId, target, 'auto_learning_path_progress', env);
+  }
+}

--- a/functions/api/admin/users.ts
+++ b/functions/api/admin/users.ts
@@ -1,5 +1,6 @@
 import type { Env } from '../../_lib/auth';
 import { getSessionUser, jsonResponse, checkCsrf } from '../../_lib/auth';
+import { RANK_ORDINALS, awardRank, type Rank } from '../../_lib/rank';
 
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   const user = await getSessionUser(request, env);
@@ -13,7 +14,14 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   let query = `
     SELECT
       u.id, u.email, u.is_member, u.is_admin, u.created_at, u.last_login,
-      p.username, p.display_name, p.institution, p.is_public
+      p.username, p.display_name, p.institution, p.is_public,
+      COALESCE(
+        (SELECT rank FROM rank_history rh WHERE rh.user_id = u.id
+         ORDER BY rank_ordinal DESC, computed_at DESC LIMIT 1),
+        'seed'
+      ) as current_rank,
+      (SELECT GROUP_CONCAT(badge_code) FROM user_achievement_badges uab
+       WHERE uab.user_id = u.id) as badge_codes
     FROM users u
     LEFT JOIN profiles p ON p.user_id = u.id
   `;
@@ -36,7 +44,11 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   const stmt = env.DB.prepare(query);
   const result = await (bindings.length > 0 ? stmt.bind(...bindings) : stmt).all();
 
-  return jsonResponse({ users: result.results });
+  const badgeCatalog = await env.DB.prepare(
+    'SELECT code, name_en, name_tr FROM achievement_badges ORDER BY name_en'
+  ).all();
+
+  return jsonResponse({ users: result.results, badge_catalog: badgeCatalog.results });
 };
 
 export const onRequestPatch: PagesFunction<Env> = async ({ request, env }) => {
@@ -47,7 +59,9 @@ export const onRequestPatch: PagesFunction<Env> = async ({ request, env }) => {
 
   const body = await request.json<{
     user_id: string;
-    action: 'verify' | 'unverify' | 'make_admin' | 'remove_admin' | 'make_private' | 'clear_bio';
+    action: 'verify' | 'unverify' | 'make_admin' | 'remove_admin' | 'make_private' | 'clear_bio'
+      | 'set_rank' | 'award_badge' | 'revoke_badge';
+    value?: string;
   }>();
 
   if (!body.user_id || !body.action) {
@@ -78,6 +92,26 @@ export const onRequestPatch: PagesFunction<Env> = async ({ request, env }) => {
     case 'clear_bio':
       await env.DB.prepare('UPDATE profiles SET bio = NULL WHERE user_id = ?').bind(body.user_id).run();
       break;
+    case 'set_rank': {
+      const rank = body.value as Rank | undefined;
+      if (!rank || !(rank in RANK_ORDINALS)) return jsonResponse({ error: 'Invalid rank' }, 400);
+      await awardRank(body.user_id, rank, 'admin_manual', env);
+      break;
+    }
+    case 'award_badge': {
+      if (!body.value) return jsonResponse({ error: 'Missing badge code' }, 400);
+      await env.DB.prepare(
+        'INSERT OR IGNORE INTO user_achievement_badges (user_id, badge_code, awarded_at, awarded_by) VALUES (?, ?, ?, ?)'
+      ).bind(body.user_id, body.value, Math.floor(Date.now() / 1000), user.id).run();
+      break;
+    }
+    case 'revoke_badge': {
+      if (!body.value) return jsonResponse({ error: 'Missing badge code' }, 400);
+      await env.DB.prepare(
+        'DELETE FROM user_achievement_badges WHERE user_id = ? AND badge_code = ?'
+      ).bind(body.user_id, body.value).run();
+      break;
+    }
     default:
       return jsonResponse({ error: 'Unknown action' }, 400);
   }

--- a/functions/api/me.ts
+++ b/functions/api/me.ts
@@ -1,5 +1,6 @@
 import type { Env } from '../_lib/auth';
 import { getSessionUser, jsonResponse } from '../_lib/auth';
+import { getCurrentRank } from '../_lib/rank';
 
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   const user = await getSessionUser(request, env);
@@ -20,6 +21,12 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     'SELECT interest FROM user_interests WHERE user_id = ?'
   ).bind(user.id).all<{ interest: string }>();
 
+  const rank = await getCurrentRank(user.id, env);
+
+  const achievementBadges = await env.DB.prepare(
+    'SELECT badge_code FROM user_achievement_badges WHERE user_id = ?'
+  ).bind(user.id).all<{ badge_code: string }>();
+
   return jsonResponse({
     user: {
       id: user.id,
@@ -30,5 +37,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     profile: profile ?? null,
     badges: badges.results.map(b => b.badge),
     interests: interests.results.map(i => i.interest),
+    rank: rank?.rank ?? 'seed',
+    achievement_badges: achievementBadges.results.map(b => b.badge_code),
   });
 };

--- a/functions/api/progress.ts
+++ b/functions/api/progress.ts
@@ -1,5 +1,6 @@
 import type { Env } from '../_lib/auth';
 import { getSessionUser, jsonResponse, checkCsrf } from '../_lib/auth';
+import { maybeAutoPromote } from '../_lib/rank';
 
 const RESOURCE_ID_RE = /^[a-z0-9_-]+$/i;
 
@@ -55,6 +56,8 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
         completed_at = CASE WHEN excluded.completed = 1 THEN excluded.completed_at ELSE completed_at END
     `).bind(user.id, item.resource_id, completed, completedAt).run();
   }
+
+  await maybeAutoPromote(user.id, env);
 
   return jsonResponse({ ok: true });
 };

--- a/functions/auth/callback.ts
+++ b/functions/auth/callback.ts
@@ -6,6 +6,7 @@ import {
   redirectResponse,
   getBaseUrl,
 } from '../_lib/auth';
+import { awardRank } from '../_lib/rank';
 
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   const url = new URL(request.url);
@@ -74,6 +75,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       'INSERT INTO users (id, google_id, email, is_member, is_admin, created_at, last_login) VALUES (?, ?, ?, 0, 0, ?, ?)'
     ).bind(newId, googleUser.id, googleUser.email, now, now).run();
     user = { id: newId, email: googleUser.email };
+    await awardRank(newId, 'seed', 'new_member_default', env);
 
     // Redirect new users to profile setup
     const { token, expires } = await createSession(user.id, env);

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -55,6 +55,8 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
                 <th class="text-left px-5 py-3 text-xs font-semibold text-gray-400 uppercase tracking-wide">User</th>
                 <th class="text-left px-5 py-3 text-xs font-semibold text-gray-400 uppercase tracking-wide">Email</th>
                 <th class="text-left px-5 py-3 text-xs font-semibold text-gray-400 uppercase tracking-wide">Status</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-gray-400 uppercase tracking-wide">Rank</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-gray-400 uppercase tracking-wide">Badges</th>
                 <th class="text-left px-5 py-3 text-xs font-semibold text-gray-400 uppercase tracking-wide">Joined</th>
                 <th class="text-right px-5 py-3 text-xs font-semibold text-gray-400 uppercase tracking-wide">Actions</th>
               </tr>
@@ -84,6 +86,14 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 <script>
   let currentFilter = 'all';
   let searchTimer: ReturnType<typeof setTimeout>;
+  let badgeCatalog: Array<{ code: string; name_en: string; name_tr: string }> = [];
+
+  const RANKS = [
+    { value: 'seed', label: '🌱 Seed' },
+    { value: 'sprout', label: '🌿 Sprout' },
+    { value: 'sapling', label: '🌳 Sapling' },
+    { value: 'legacy_tree', label: '🌲 Legacy Tree' },
+  ];
 
   function showToast(message: string, isError = false) {
     const toast = document.getElementById('toast')!;
@@ -97,12 +107,12 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
     return new Date(ts * 1000).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
   }
 
-  async function doAction(userId: string, action: string, btn: HTMLButtonElement) {
+  async function doAction(userId: string, action: string, btn: HTMLButtonElement | HTMLSelectElement, value?: string) {
     btn.disabled = true;
     const res = await fetch('/api/admin/users', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ user_id: userId, action }),
+      body: JSON.stringify({ user_id: userId, action, value }),
     });
     if (res.ok) {
       showToast('Done');
@@ -143,6 +153,25 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
         ? `<button data-id="${u.id}" data-action="unverify" class="action-btn text-xs px-3 py-1.5 rounded-lg border border-border text-gray-500 hover:border-red hover:text-red transition-colors">Unverify</button>`
         : `<button data-id="${u.id}" data-action="verify" class="action-btn text-xs px-3 py-1.5 rounded-lg border border-green-200 text-green-700 hover:bg-green-50 transition-colors">Verify</button>`;
 
+      const rankSelect = `
+        <select data-id="${u.id}" class="rank-select text-xs px-2 py-1.5 rounded-lg border border-border text-navy bg-white focus:outline-none focus:border-navy-mid">
+          ${RANKS.map(r => `<option value="${r.value}" ${u.current_rank === r.value ? 'selected' : ''}>${r.label}</option>`).join('')}
+        </select>`;
+
+      const earnedCodes = new Set((u.badge_codes || '').split(',').filter(Boolean));
+      const badgeChips = badgeCatalog.map(b => `
+        <button
+          data-id="${u.id}"
+          data-code="${b.code}"
+          data-earned="${earnedCodes.has(b.code)}"
+          class="badge-chip text-xs px-2 py-1 rounded-full border transition-colors ${
+            earnedCodes.has(b.code)
+              ? 'bg-navy text-white border-navy'
+              : 'bg-white text-gray-400 border-border hover:border-navy-mid'
+          }"
+          title="${b.name_en}"
+        >${b.name_tr}</button>`).join(' ');
+
       const moreActions = `
         <div class="relative inline-block">
           <button data-menu="${u.id}" class="more-btn text-xs px-2 py-1.5 rounded-lg border border-border text-gray-400 hover:text-navy hover:border-navy-mid transition-colors">⋯</button>
@@ -165,6 +194,8 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
           </td>
           <td class="px-5 py-4 text-gray-500">${u.email}</td>
           <td class="px-5 py-4">${memberBadge}${adminBadge}${privateBadge}</td>
+          <td class="px-5 py-4">${rankSelect}</td>
+          <td class="px-5 py-4"><div class="flex flex-wrap gap-1 max-w-[220px]">${badgeChips}</div></td>
           <td class="px-5 py-4 text-gray-400">${formatDate(u.created_at)}</td>
           <td class="px-5 py-4 text-right">
             <div class="flex items-center justify-end gap-2">
@@ -180,6 +211,23 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
       btn.addEventListener('click', (e) => {
         const b = e.currentTarget as HTMLButtonElement;
         doAction(b.dataset.id!, b.dataset.action!, b);
+      });
+    });
+
+    // Rank select
+    tbody.querySelectorAll('.rank-select').forEach(sel => {
+      sel.addEventListener('change', (e) => {
+        const s = e.currentTarget as HTMLSelectElement;
+        doAction(s.dataset.id!, 'set_rank', s, s.value);
+      });
+    });
+
+    // Badge chips (toggle award/revoke)
+    tbody.querySelectorAll('.badge-chip').forEach(chip => {
+      chip.addEventListener('click', (e) => {
+        const b = e.currentTarget as HTMLButtonElement;
+        const earned = b.dataset.earned === 'true';
+        doAction(b.dataset.id!, earned ? 'revoke_badge' : 'award_badge', b, b.dataset.code);
       });
     });
 
@@ -209,7 +257,8 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 
     const res = await fetch(`/api/admin/users?${params}`);
     if (!res.ok) return;
-    const data = await res.json() as { users: any[] };
+    const data = await res.json() as { users: any[]; badge_catalog: typeof badgeCatalog };
+    badgeCatalog = data.badge_catalog ?? [];
     renderUsers(data.users);
 
     // Update stats


### PR DESCRIPTION
PR #18 merged with an empty diff (branch name collision with #17 meant the real commit was never pushed -- my mistake, not caught before merging). This PR has the actual content #18 was supposed to have:

- New members default to Seed at signup.
- Seed -> Sprout -> Sapling auto-promotes off learning-path completion count.
- Legacy Tree intentionally excluded from auto-promotion (admin-only, no automatic community-contribution signal yet).
- functions/_lib/rank.ts centralizes rank<->ordinal mapping and read/write helpers.
- /api/me returns rank and achievement_badges.
- Admin panel: Rank column (dropdown -> set_rank) and Badges column (toggle chips -> award_badge/revoke_badge) for manual override.

Verified locally: npm run build succeeds, npx astro check adds no new error category vs main's existing gap (confirmed by diffing error counts).