### PR TITLE
Render Growth rank and Pipeline badges on the actual site

### DIFF
--- a/functions/api/members.ts
+++ b/functions/api/members.ts
@@ -37,7 +37,13 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
       p.username, p.display_name, p.avatar_url, p.institution, p.bio,
       u.is_member,
       (SELECT GROUP_CONCAT(ub.badge) FROM user_badges ub WHERE ub.user_id = p.user_id) AS badges_raw,
-      (SELECT GROUP_CONCAT(ui.interest) FROM user_interests ui WHERE ui.user_id = p.user_id) AS interests_raw
+      (SELECT GROUP_CONCAT(ui.interest) FROM user_interests ui WHERE ui.user_id = p.user_id) AS interests_raw,
+      COALESCE(
+        (SELECT rh.rank FROM rank_history rh WHERE rh.user_id = p.user_id
+         ORDER BY rh.rank_ordinal DESC, rh.computed_at DESC LIMIT 1),
+        'seed'
+      ) as current_rank,
+      (SELECT GROUP_CONCAT(uab.badge_code) FROM user_achievement_badges uab WHERE uab.user_id = p.user_id) AS achievement_badges_raw
     FROM profiles p
     JOIN users u ON u.id = p.user_id
     ${where}
@@ -56,6 +62,8 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     is_member: number;
     badges_raw: string | null;
     interests_raw: string | null;
+    current_rank: string;
+    achievement_badges_raw: string | null;
   }>();
 
   const members = result.results.map(m => ({
@@ -63,8 +71,11 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     is_member: m.is_member === 1,
     badges: m.badges_raw ? m.badges_raw.split(',') : [],
     interests: m.interests_raw ? m.interests_raw.split(',') : [],
+    rank: m.current_rank,
+    achievement_badges: m.achievement_badges_raw ? m.achievement_badges_raw.split(',') : [],
     badges_raw: undefined,
     interests_raw: undefined,
+    achievement_badges_raw: undefined,
   }));
 
   return jsonResponse({ members });

--- a/functions/api/members/[username].ts
+++ b/functions/api/members/[username].ts
@@ -12,7 +12,13 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, params, env })
       p.username, p.display_name, p.avatar_url, p.institution, p.bio, p.is_public,
       u.is_member,
       (SELECT GROUP_CONCAT(ub.badge) FROM user_badges ub WHERE ub.user_id = p.user_id) AS badges_raw,
-      (SELECT GROUP_CONCAT(ui.interest) FROM user_interests ui WHERE ui.user_id = p.user_id) AS interests_raw
+      (SELECT GROUP_CONCAT(ui.interest) FROM user_interests ui WHERE ui.user_id = p.user_id) AS interests_raw,
+      COALESCE(
+        (SELECT rh.rank FROM rank_history rh WHERE rh.user_id = p.user_id
+         ORDER BY rh.rank_ordinal DESC, rh.computed_at DESC LIMIT 1),
+        'seed'
+      ) as current_rank,
+      (SELECT GROUP_CONCAT(uab.badge_code) FROM user_achievement_badges uab WHERE uab.user_id = p.user_id) AS achievement_badges_raw
     FROM profiles p
     JOIN users u ON u.id = p.user_id
     WHERE p.username = ? AND p.is_public = 1
@@ -26,6 +32,8 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, params, env })
     is_member: number;
     badges_raw: string | null;
     interests_raw: string | null;
+    current_rank: string;
+    achievement_badges_raw: string | null;
   }>();
 
   if (!profile) return jsonResponse({ error: 'Not found' }, 404);
@@ -40,6 +48,8 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, params, env })
       is_member: profile.is_member === 1,
       badges: profile.badges_raw ? profile.badges_raw.split(',') : [],
       interests: profile.interests_raw ? profile.interests_raw.split(',') : [],
+      rank: profile.current_rank,
+      achievement_badges: profile.achievement_badges_raw ? profile.achievement_badges_raw.split(',') : [],
     }
   });
 };

--- a/src/lib/badges.ts
+++ b/src/lib/badges.ts
@@ -1,0 +1,161 @@
+// Coin-medallion badge rendering: Growth rank (seed/sprout/sapling/legacy_tree)
+// and Pipeline achievement badges. Design settled through iteration in
+// https://claude.ai/code/artifact/639aefa6-a07b-4132-861f-1fb48e664f66 --
+// reeded edge, TR legend on the top half of the rim, EN on the bottom half,
+// same font/size for both, small seam dots where they meet. 48px is the
+// floor for legibility; don't render smaller.
+
+export type Rank = 'seed' | 'sprout' | 'sapling' | 'legacy_tree';
+export type AchievementCode = 'variant_analysis' | 'read_qc' | 'read_alignment' | 'genome_assembly';
+
+const RANK_LABELS: Record<Rank, { tr: string; en: string }> = {
+  seed: { tr: 'TOHUM', en: 'SEED' },
+  sprout: { tr: 'FİLİZ', en: 'SPROUT' },
+  sapling: { tr: 'FİDAN', en: 'SAPLING' },
+  legacy_tree: { tr: 'ÇINAR', en: 'LEGACY TREE' },
+};
+
+const ACHIEVEMENT_LABELS: Record<AchievementCode, { tr: string; en: string }> = {
+  variant_analysis: { tr: 'VARYANT ANALİZİ', en: 'VARIANT ANALYSIS' },
+  read_qc: { tr: 'OKUMA QC', en: 'READ QC' },
+  read_alignment: { tr: 'OKUMA HİZALAMA', en: 'READ ALIGNMENT' },
+  genome_assembly: { tr: 'GENOM MONTAJI', en: 'GENOME ASSEMBLY' },
+};
+
+const RANK_ICONS: Record<Rank, string> = {
+  seed: `
+    <ellipse cx="50" cy="55" rx="12" ry="15" fill="#8a6a45"/>
+    <path d="M50 41 C52 46 52 51 50 56" stroke="#5c4229" stroke-width="1.4" stroke-linecap="round" fill="none"/>
+    <ellipse cx="45.5" cy="50" rx="3.2" ry="4.6" fill="#a9855c" opacity="0.6"/>`,
+  sprout: `
+    <path d="M50 70 V52" stroke="#4f9d5c" stroke-width="2.6" stroke-linecap="round"/>
+    <path d="M50 55 C41 55 37 48 35 40 C45 40 50 46 50 55Z" fill="#5cb56a"/>
+    <path d="M50 50 C59 50 63 43 65 35 C55 35 50 42 50 50Z" fill="#4f9d5c"/>
+    <ellipse cx="50" cy="71" rx="7.5" ry="2.2" fill="#2f3d2c" opacity="0.4"/>`,
+  sapling: `
+    <path d="M50 72 V54" stroke="#6b4a2c" stroke-width="3.4" stroke-linecap="round"/>
+    <circle cx="50" cy="42" r="14" fill="#4f9d5c"/>
+    <circle cx="40" cy="47" r="7.6" fill="#5cb56a"/>
+    <circle cx="60" cy="47" r="7.6" fill="#458750"/>
+    <ellipse cx="50" cy="73" rx="9" ry="2.3" fill="#2f3d2c" opacity="0.4"/>`,
+  legacy_tree: `
+    <path d="M50 74 V56" stroke="#8a6a45" stroke-width="4.6" stroke-linecap="round"/>
+    <path d="M50 65 L42 71 M50 65 L58 71" stroke="#8a6a45" stroke-width="2.4" stroke-linecap="round"/>
+    <circle cx="50" cy="41" r="15.5" fill="#d1a13a"/>
+    <circle cx="37" cy="47" r="9" fill="#c99a37"/>
+    <circle cx="63" cy="47" r="9" fill="#b98d34"/>
+    <circle cx="50" cy="32" r="8.5" fill="#dcae45"/>
+    <ellipse cx="50" cy="75" rx="11" ry="2.4" fill="#2f3d2c" opacity="0.45"/>`,
+};
+
+const ACHIEVEMENT_ICONS: Record<AchievementCode, string> = {
+  variant_analysis: `
+    <rect x="26" y="43" width="48" height="5" rx="2" fill="#3fa7ad"/>
+    <rect x="26" y="53" width="48" height="5" rx="2" fill="#3fa7ad"/>
+    <rect x="26" y="63" width="48" height="5" rx="2" fill="#3fa7ad"/>
+    <rect x="52" y="40" width="4" height="30" rx="1" fill="#e0503f"/>`,
+  read_qc: `
+    <line x1="32" y1="50" x2="68" y2="50" stroke="#3fa7ad" stroke-width="2.2" stroke-linecap="round"/>
+    <line x1="32" y1="42" x2="32" y2="58" stroke="#8fa0ba" stroke-width="1.8" stroke-linecap="round"/>
+    <line x1="68" y1="42" x2="68" y2="58" stroke="#8fa0ba" stroke-width="1.8" stroke-linecap="round"/>
+    <line x1="23" y1="41" x2="29" y2="47" stroke="#e0503f" stroke-width="2" stroke-linecap="round"/>
+    <line x1="23" y1="47" x2="29" y2="41" stroke="#e0503f" stroke-width="2" stroke-linecap="round"/>
+    <line x1="71" y1="41" x2="77" y2="47" stroke="#e0503f" stroke-width="2" stroke-linecap="round"/>
+    <line x1="71" y1="47" x2="77" y2="41" stroke="#e0503f" stroke-width="2" stroke-linecap="round"/>`,
+  read_alignment: `
+    <rect x="26" y="43" width="48" height="5" rx="2" fill="#3fa7ad"/>
+    <rect x="32" y="53" width="36" height="5" rx="2" fill="#3fa7ad"/>
+    <rect x="26" y="63" width="48" height="5" rx="2" fill="#3fa7ad"/>`,
+  genome_assembly: `
+    <path d="M40 34 C40 42 60 42 60 50 C60 58 40 58 40 66" stroke="#8b6fd1" stroke-width="2.1" fill="none"/>
+    <path d="M60 34 C60 42 40 42 40 50 C40 58 60 58 60 66" stroke="#8b6fd1" stroke-width="2.1" fill="none" opacity="0.55"/>
+    <line x1="42" y1="38" x2="58" y2="38" stroke="#8fa0ba" stroke-width="1.5"/>
+    <line x1="40.5" y1="46" x2="59.5" y2="46" stroke="#8fa0ba" stroke-width="1.5"/>
+    <line x1="40.5" y1="54" x2="59.5" y2="54" stroke="#8fa0ba" stroke-width="1.5"/>
+    <line x1="42" y1="62" x2="58" y2="62" stroke="#8fa0ba" stroke-width="1.5"/>`,
+};
+
+const SURFACE = '#16233a';
+const SURFACE_PEAK = '#1c2c47';
+const RING_GROWTH = '#4f9d5c';
+const RING_GROWTH_PEAK = '#d1a13a';
+const RING_PIPELINE = '#3fa7ad';
+
+let reedTicksCache = '';
+function reedTicks(): string {
+  if (reedTicksCache) return reedTicksCache;
+  const TICKS = 60, R_IN = 40, R_OUT = 44;
+  const parts: string[] = [];
+  for (let i = 0; i < TICKS; i++) {
+    const a = (i / TICKS) * Math.PI * 2;
+    const cos = Math.cos(a), sin = Math.sin(a);
+    const x1 = (50 + R_IN * cos).toFixed(2), y1 = (50 + R_IN * sin).toFixed(2);
+    const x2 = (50 + R_OUT * cos).toFixed(2), y2 = (50 + R_OUT * sin).toFixed(2);
+    parts.push(`<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="currentColor" stroke-width="1" opacity="0.75"/>`);
+  }
+  reedTicksCache = parts.join('');
+  return reedTicksCache;
+}
+
+let uidCounter = 0;
+
+function medallionSvg(opts: {
+  size: number;
+  ring: string;
+  surface: string;
+  tr: string;
+  en: string;
+  icon: string;
+  title: string;
+}): string {
+  const uid = `bdg-${uidCounter++}`;
+  return `
+    <svg viewBox="0 0 100 100" width="${opts.size}" height="${opts.size}" style="color:${opts.ring}; overflow:visible; flex-shrink:0;" role="img" aria-label="${opts.title}">
+      <circle cx="50" cy="50" r="45" fill="${opts.surface}" stroke="${opts.ring}" stroke-width="1"/>
+      <g>${reedTicks()}</g>
+      <circle cx="17" cy="50" r="1.3" fill="${opts.ring}" opacity="0.85"/>
+      <circle cx="83" cy="50" r="1.3" fill="${opts.ring}" opacity="0.85"/>
+      <path id="${uid}t" d="M 17,50 A 33,33 0 0 1 83,50" fill="none"/>
+      <text font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-weight="600" font-size="7.2" letter-spacing="0.02em" fill="#eef3f8"><textPath href="#${uid}t" startOffset="50%" text-anchor="middle">${opts.tr}</textPath></text>
+      <path id="${uid}b" d="M 83,50 A 33,33 0 0 1 17,50" fill="none"/>
+      <text font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-weight="600" font-size="7.2" letter-spacing="0.02em" fill="#eef3f8"><textPath href="#${uid}b" startOffset="50%" text-anchor="middle">${opts.en}</textPath></text>
+      ${opts.icon}
+    </svg>`;
+}
+
+/** Minimum legible size -- smaller was tested and rejected (see the design artifact). */
+export const MIN_BADGE_SIZE = 48;
+
+export function rankBadgeSvg(rank: string, size: number = MIN_BADGE_SIZE): string {
+  const key = (rank as Rank) in RANK_LABELS ? (rank as Rank) : 'seed';
+  const label = RANK_LABELS[key];
+  const isPeak = key === 'legacy_tree';
+  return medallionSvg({
+    size,
+    ring: isPeak ? RING_GROWTH_PEAK : RING_GROWTH,
+    surface: isPeak ? SURFACE_PEAK : SURFACE,
+    tr: label.tr,
+    en: label.en,
+    icon: RANK_ICONS[key],
+    title: `${label.en} rank`,
+  });
+}
+
+export function achievementBadgeSvg(code: string, size: number = MIN_BADGE_SIZE): string | null {
+  if (!(code in ACHIEVEMENT_LABELS)) return null;
+  const key = code as AchievementCode;
+  const label = ACHIEVEMENT_LABELS[key];
+  return medallionSvg({
+    size,
+    ring: RING_PIPELINE,
+    surface: SURFACE,
+    tr: label.tr,
+    en: label.en,
+    icon: ACHIEVEMENT_ICONS[key],
+    title: `${label.en} badge`,
+  });
+}
+
+export function achievementLabel(code: string): string {
+  return (ACHIEVEMENT_LABELS as Record<string, { en: string }>)[code]?.en ?? code;
+}

--- a/src/pages/account/index.astro
+++ b/src/pages/account/index.astro
@@ -1,13 +1,5 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-
-const BADGE_LABELS: Record<string, string> = {
-  open_to_work:        'Looking for a job / internship',
-  open_to_collaborate: 'Open to collaborate on a project',
-  open_to_mentor:      'Open to mentoring',
-  seeking_mentor:      'Looking for a mentor',
-  open_to_review:      'Open to reviewing papers / code',
-};
 ---
 
 <BaseLayout pageTitle="My Profile — RSG Turkey" description="Your RSG Turkey member profile.">
@@ -64,6 +56,21 @@ const BADGE_LABELS: Record<string, string> = {
           </div>
         </div>
 
+        <!-- Rank -->
+        <div id="rankCard" class="hidden bg-white rounded-2xl border border-border shadow-sm p-6 flex items-center gap-5">
+          <div id="rankBadgeWrap"></div>
+          <div>
+            <h2 class="text-sm font-semibold text-navy mb-1">Growth rank</h2>
+            <p id="rankDesc" class="text-sm text-gray-500"></p>
+          </div>
+        </div>
+
+        <!-- Achievement badges -->
+        <div id="achievementsCard" class="hidden bg-white rounded-2xl border border-border shadow-sm p-6">
+          <h2 class="text-sm font-semibold text-navy mb-3">Pipeline badges</h2>
+          <div id="achievementsList" class="flex flex-wrap gap-4"></div>
+        </div>
+
         <!-- Status badges -->
         <div id="badgesCard" class="hidden bg-white rounded-2xl border border-border shadow-sm p-6">
           <h2 class="text-sm font-semibold text-navy mb-3">Status</h2>
@@ -100,12 +107,32 @@ const BADGE_LABELS: Record<string, string> = {
   </div>
 </BaseLayout>
 
-<script define:vars={{ BADGE_LABELS }}>
+<script>
+  import { rankBadgeSvg, achievementBadgeSvg, achievementLabel } from '../../lib/badges.ts';
+
+  // define:vars forces a script to run as a classic (non-module) script, which
+  // can't use `import` -- so this stays a plain static-object literal here
+  // instead, kept in sync with the frontmatter copy above by hand (it's tiny).
+  const BADGE_LABELS: Record<string, string> = {
+    open_to_work: 'Looking for a job / internship',
+    open_to_collaborate: 'Open to collaborate on a project',
+    open_to_mentor: 'Open to mentoring',
+    seeking_mentor: 'Looking for a mentor',
+    open_to_review: 'Open to reviewing papers / code',
+  };
+
+  const RANK_DESCRIPTIONS: Record<string, string> = {
+    seed: 'Just getting started.',
+    sprout: 'Making steady progress through the learning paths.',
+    sapling: 'Deep, independent progress -- learning on your own now.',
+    legacy_tree: "Recognized for giving back to the community, not just for what you've completed.",
+  };
+
   (async () => {
-    const loading = document.getElementById('loadingState');
-    const notLoggedIn = document.getElementById('notLoggedIn');
-    const noProfile = document.getElementById('noProfile');
-    const profileContent = document.getElementById('profileContent');
+    const loading = document.getElementById('loadingState')!;
+    const notLoggedIn = document.getElementById('notLoggedIn')!;
+    const noProfile = document.getElementById('noProfile')!;
+    const profileContent = document.getElementById('profileContent')!;
 
     try {
       const res = await fetch('/api/me');
@@ -128,8 +155,8 @@ const BADGE_LABELS: Record<string, string> = {
       const p = data.profile;
 
       // Avatar
-      const avatarWrap = document.getElementById('avatarWrap');
-      const avatarFallback = document.getElementById('avatarFallback');
+      const avatarWrap = document.getElementById('avatarWrap')!;
+      const avatarFallback = document.getElementById('avatarFallback')!;
       if (p.avatar_url) {
         avatarWrap.innerHTML = `<img src="${p.avatar_url}" class="w-20 h-20 rounded-full object-cover" />`;
       } else {
@@ -137,34 +164,55 @@ const BADGE_LABELS: Record<string, string> = {
       }
 
       // Basic info
-      document.getElementById('displayName').textContent = p.display_name;
-      document.getElementById('usernameEl').textContent = '@' + p.username;
+      document.getElementById('displayName')!.textContent = p.display_name;
+      document.getElementById('usernameEl')!.textContent = '@' + p.username;
 
       if (p.institution) {
-        const el = document.getElementById('institutionEl');
+        const el = document.getElementById('institutionEl')!;
         el.textContent = p.institution;
         el.classList.remove('hidden');
       }
 
       if (p.bio) {
-        const el = document.getElementById('bioEl');
+        const el = document.getElementById('bioEl')!;
         el.textContent = p.bio;
         el.classList.remove('hidden');
       }
 
       // Member badge
       if (data.user.is_member) {
-        document.getElementById('memberBadge').classList.remove('hidden');
+        document.getElementById('memberBadge')!.classList.remove('hidden');
       } else {
-        document.getElementById('membershipCta').classList.remove('hidden');
+        document.getElementById('membershipCta')!.classList.remove('hidden');
+      }
+
+      // Growth rank
+      const rank = data.rank || 'seed';
+      document.getElementById('rankCard')!.classList.remove('hidden');
+      document.getElementById('rankBadgeWrap')!.innerHTML = rankBadgeSvg(rank, 64);
+      document.getElementById('rankDesc')!.textContent = RANK_DESCRIPTIONS[rank] || '';
+
+      // Pipeline achievement badges
+      if (data.achievement_badges && data.achievement_badges.length > 0) {
+        const card = document.getElementById('achievementsCard')!;
+        const list = document.getElementById('achievementsList')!;
+        card.classList.remove('hidden');
+        data.achievement_badges.forEach((code: string) => {
+          const svg = achievementBadgeSvg(code, 56);
+          if (!svg) return;
+          const wrap = document.createElement('div');
+          wrap.className = 'flex flex-col items-center gap-1.5';
+          wrap.innerHTML = svg + `<span class="text-xs text-gray-500 text-center max-w-[80px]">${achievementLabel(code)}</span>`;
+          list.appendChild(wrap);
+        });
       }
 
       // Status badges
       if (data.badges && data.badges.length > 0) {
-        const card = document.getElementById('badgesCard');
-        const list = document.getElementById('badgesList');
+        const card = document.getElementById('badgesCard')!;
+        const list = document.getElementById('badgesList')!;
         card.classList.remove('hidden');
-        data.badges.forEach(badge => {
+        data.badges.forEach((badge: string) => {
           const span = document.createElement('span');
           span.className = 'text-xs px-3 py-1.5 rounded-full bg-navy-light text-navy border border-navy/20 font-medium';
           span.textContent = BADGE_LABELS[badge] || badge;
@@ -174,10 +222,10 @@ const BADGE_LABELS: Record<string, string> = {
 
       // Interests
       if (data.interests && data.interests.length > 0) {
-        const card = document.getElementById('interestsCard');
-        const list = document.getElementById('interestsList');
+        const card = document.getElementById('interestsCard')!;
+        const list = document.getElementById('interestsList')!;
         card.classList.remove('hidden');
-        data.interests.forEach(interest => {
+        data.interests.forEach((interest: string) => {
           const span = document.createElement('span');
           span.className = 'text-xs px-3 py-1.5 rounded-full bg-[#F7F7F6] text-gray-600 border border-border';
           span.textContent = interest;

--- a/src/pages/members.astro
+++ b/src/pages/members.astro
@@ -67,22 +67,35 @@ const BADGE_LABELS: Record<string, string> = {
   </div>
 </BaseLayout>
 
-<script define:vars={{ BADGE_LABELS }}>
+<script>
+  import { rankBadgeSvg } from '../lib/badges.ts';
+
+  // define:vars forces a script to run as a classic (non-module) script, which
+  // can't use `import` -- so this stays a plain static-object literal here
+  // instead, kept in sync with the frontmatter copy above by hand (it's tiny).
+  const BADGE_LABELS: Record<string, string> = {
+    open_to_work: 'Looking for a job / internship',
+    open_to_collaborate: 'Open to collaborate on a project',
+    open_to_mentor: 'Open to mentoring',
+    seeking_mentor: 'Looking for a mentor',
+    open_to_review: 'Open to reviewing papers / code',
+  };
+
   const LIMIT = 24;
   let offset = 0;
   let isLoading = false;
   let hasMore = false;
-  let searchTimer;
+  let searchTimer: ReturnType<typeof setTimeout>;
 
   function getFilters() {
     return {
-      search: document.getElementById('searchInput').value.trim(),
-      interest: document.getElementById('interestFilter').value,
-      badge: document.getElementById('badgeFilter').value,
+      search: (document.getElementById('searchInput') as HTMLInputElement).value.trim(),
+      interest: (document.getElementById('interestFilter') as HTMLSelectElement).value,
+      badge: (document.getElementById('badgeFilter') as HTMLSelectElement).value,
     };
   }
 
-  function avatarHtml(member) {
+  function avatarHtml(member: any) {
     if (member.avatar_url) {
       return `<img src="${member.avatar_url}" class="w-14 h-14 rounded-full object-cover" />`;
     }
@@ -90,12 +103,12 @@ const BADGE_LABELS: Record<string, string> = {
     return `<div style="width:56px;height:56px;border-radius:50%;background:#e8edf5;display:flex;align-items:center;justify-content:center;font-size:20px;font-weight:700;color:#0f2045;">${initial}</div>`;
   }
 
-  function renderCard(member) {
-    const badges = (member.badges || []).slice(0, 2).map(b =>
+  function renderCard(member: any) {
+    const badges = (member.badges || []).slice(0, 2).map((b: string) =>
       `<span style="font-size:11px;padding:3px 10px;border-radius:99px;background:#e8edf5;color:#0f2045;font-weight:500;">${BADGE_LABELS[b] || b}</span>`
     ).join('');
 
-    const interests = (member.interests || []).slice(0, 3).map(i =>
+    const interests = (member.interests || []).slice(0, 3).map((i: string) =>
       `<span style="font-size:11px;padding:3px 10px;border-radius:99px;background:#f3f4f6;color:#6b7280;border:1px solid #e5e7eb;">${i}</span>`
     ).join('');
 
@@ -115,6 +128,7 @@ const BADGE_LABELS: Record<string, string> = {
             <div style="font-size:12px;color:#9ca3af;margin-top:2px;">@${member.username}</div>
             ${member.institution ? `<div style="font-size:12px;color:#6b7280;margin-top:2px;">${member.institution}</div>` : ''}
           </div>
+          <div style="flex-shrink:0;">${rankBadgeSvg(member.rank || 'seed', 48)}</div>
         </div>
         ${member.bio ? `<p style="font-size:13px;color:#6b7280;line-height:1.5;margin-bottom:10px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;">${member.bio}</p>` : ''}
         ${badges ? `<div style="display:flex;flex-wrap:wrap;gap:5px;margin-bottom:8px;">${badges}</div>` : ''}
@@ -128,14 +142,14 @@ const BADGE_LABELS: Record<string, string> = {
 
     if (reset) {
       offset = 0;
-      document.getElementById('memberGrid').innerHTML = '';
-      document.getElementById('memberGrid').classList.add('hidden');
-      document.getElementById('emptyState').classList.add('hidden');
-      document.getElementById('loadingState').classList.remove('hidden');
+      document.getElementById('memberGrid')!.innerHTML = '';
+      document.getElementById('memberGrid')!.classList.add('hidden');
+      document.getElementById('emptyState')!.classList.add('hidden');
+      document.getElementById('loadingState')!.classList.remove('hidden');
     }
 
     const { search, interest, badge } = getFilters();
-    const params = new URLSearchParams({ limit: LIMIT, offset });
+    const params = new URLSearchParams({ limit: String(LIMIT), offset: String(offset) });
     if (search) params.set('search', search);
     if (interest) params.set('interest', interest);
     if (badge) params.set('badge', badge);
@@ -143,23 +157,23 @@ const BADGE_LABELS: Record<string, string> = {
     const res = await fetch(`/api/members?${params}`);
     const data = await res.json();
 
-    document.getElementById('loadingState').classList.add('hidden');
+    document.getElementById('loadingState')!.classList.add('hidden');
 
-    const grid = document.getElementById('memberGrid');
+    const grid = document.getElementById('memberGrid')!;
     const members = data.members || [];
     hasMore = members.length === LIMIT;
     offset += members.length;
 
     if (reset && members.length === 0) {
-      document.getElementById('emptyState').classList.remove('hidden');
+      document.getElementById('emptyState')!.classList.remove('hidden');
     } else {
       grid.classList.remove('hidden');
-      members.forEach(m => {
+      members.forEach((m: any) => {
         grid.insertAdjacentHTML('beforeend', renderCard(m));
       });
     }
 
-    document.getElementById('loadMoreBtn').classList.toggle('hidden', !hasMore);
+    document.getElementById('loadMoreBtn')!.classList.toggle('hidden', !hasMore);
     isLoading = false;
   }
 
@@ -175,11 +189,11 @@ const BADGE_LABELS: Record<string, string> = {
   })();
 
   // Search & filters
-  document.getElementById('searchInput').addEventListener('input', () => {
+  document.getElementById('searchInput')!.addEventListener('input', () => {
     clearTimeout(searchTimer);
     searchTimer = setTimeout(() => loadMembers(true), 350);
   });
-  document.getElementById('interestFilter').addEventListener('change', () => loadMembers(true));
-  document.getElementById('badgeFilter').addEventListener('change', () => loadMembers(true));
-  document.getElementById('loadMoreBtn').addEventListener('click', () => loadMembers(false));
+  document.getElementById('interestFilter')!.addEventListener('change', () => loadMembers(true));
+  document.getElementById('badgeFilter')!.addEventListener('change', () => loadMembers(true));
+  document.getElementById('loadMoreBtn')!.addEventListener('click', () => loadMembers(false));
 </script>

--- a/src/pages/members/profile.astro
+++ b/src/pages/members/profile.astro
@@ -1,13 +1,5 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-
-const BADGE_LABELS: Record<string, string> = {
-  open_to_work:        'Looking for a job / internship',
-  open_to_collaborate: 'Open to collaborate on a project',
-  open_to_mentor:      'Open to mentoring',
-  seeking_mentor:      'Looking for a mentor',
-  open_to_review:      'Open to reviewing papers / code',
-};
 ---
 
 <BaseLayout pageTitle="Member Profile — RSG Turkey" description="RSG Turkey member profile.">
@@ -39,7 +31,13 @@ const BADGE_LABELS: Record<string, string> = {
               <p id="institutionEl" class="text-sm text-gray-500 mt-1 hidden"></p>
               <p id="bioEl" class="text-sm text-gray-600 mt-3 leading-relaxed hidden"></p>
             </div>
+            <div id="rankBadgeWrap" class="shrink-0"></div>
           </div>
+        </div>
+
+        <div id="achievementsCard" class="hidden bg-white rounded-2xl border border-border shadow-sm p-6">
+          <h2 class="text-sm font-semibold text-navy mb-3">Pipeline badges</h2>
+          <div id="achievementsList" class="flex flex-wrap gap-4"></div>
         </div>
 
         <div id="badgesCard" class="hidden bg-white rounded-2xl border border-border shadow-sm p-6">
@@ -57,7 +55,20 @@ const BADGE_LABELS: Record<string, string> = {
   </div>
 </BaseLayout>
 
-<script define:vars={{ BADGE_LABELS }}>
+<script>
+  import { rankBadgeSvg, achievementBadgeSvg, achievementLabel } from '../../lib/badges.ts';
+
+  // define:vars forces a script to run as a classic (non-module) script, which
+  // can't use `import` -- so this stays a plain static-object literal here
+  // instead, kept in sync with the frontmatter copy above by hand (it's tiny).
+  const BADGE_LABELS: Record<string, string> = {
+    open_to_work: 'Looking for a job / internship',
+    open_to_collaborate: 'Open to collaborate on a project',
+    open_to_mentor: 'Open to mentoring',
+    seeking_mentor: 'Looking for a mentor',
+    open_to_review: 'Open to reviewing papers / code',
+  };
+
   (async () => {
     // Require login
     const authRes = await fetch('/api/me');
@@ -76,22 +87,22 @@ const BADGE_LABELS: Record<string, string> = {
     }
 
     const res = await fetch(`/api/members/${username}`);
-    document.getElementById('loadingState').classList.add('hidden');
+    document.getElementById('loadingState')!.classList.add('hidden');
 
     if (!res.ok) {
-      document.getElementById('notFound').classList.remove('hidden');
+      document.getElementById('notFound')!.classList.remove('hidden');
       return;
     }
 
     const data = await res.json();
     const m = data.member;
-    document.getElementById('profileContent').classList.remove('hidden');
+    document.getElementById('profileContent')!.classList.remove('hidden');
 
     // Update page title
     document.title = `@${m.username} — RSG Turkey`;
 
     // Avatar
-    const avatarWrap = document.getElementById('avatarWrap');
+    const avatarWrap = document.getElementById('avatarWrap')!;
     if (m.avatar_url) {
       avatarWrap.innerHTML = `<img src="${m.avatar_url}" style="width:80px;height:80px;border-radius:50%;object-fit:cover;" />`;
     } else {
@@ -99,27 +110,43 @@ const BADGE_LABELS: Record<string, string> = {
       avatarWrap.innerHTML = `<div style="width:80px;height:80px;border-radius:50%;background:#e8edf5;display:flex;align-items:center;justify-content:center;font-size:28px;font-weight:700;color:#0f2045;">${initial}</div>`;
     }
 
-    document.getElementById('displayName').textContent = m.display_name;
-    document.getElementById('usernameEl').textContent = '@' + m.username;
+    document.getElementById('displayName')!.textContent = m.display_name;
+    document.getElementById('usernameEl')!.textContent = '@' + m.username;
 
-    if (m.is_member) document.getElementById('memberBadge').classList.remove('hidden');
+    if (m.is_member) document.getElementById('memberBadge')!.classList.remove('hidden');
 
     if (m.institution) {
-      const el = document.getElementById('institutionEl');
+      const el = document.getElementById('institutionEl')!;
       el.textContent = m.institution;
       el.classList.remove('hidden');
     }
 
     if (m.bio) {
-      const el = document.getElementById('bioEl');
+      const el = document.getElementById('bioEl')!;
       el.textContent = m.bio;
       el.classList.remove('hidden');
     }
 
+    document.getElementById('rankBadgeWrap')!.innerHTML = rankBadgeSvg(m.rank || 'seed', 64);
+
+    if (m.achievement_badges && m.achievement_badges.length > 0) {
+      const card = document.getElementById('achievementsCard')!;
+      const list = document.getElementById('achievementsList')!;
+      card.classList.remove('hidden');
+      m.achievement_badges.forEach((code: string) => {
+        const svg = achievementBadgeSvg(code, 56);
+        if (!svg) return;
+        const wrap = document.createElement('div');
+        wrap.className = 'flex flex-col items-center gap-1.5';
+        wrap.innerHTML = svg + `<span class="text-xs text-gray-500 text-center max-w-[80px]">${achievementLabel(code)}</span>`;
+        list.appendChild(wrap);
+      });
+    }
+
     if (m.badges && m.badges.length > 0) {
-      document.getElementById('badgesCard').classList.remove('hidden');
-      const list = document.getElementById('badgesList');
-      m.badges.forEach(b => {
+      document.getElementById('badgesCard')!.classList.remove('hidden');
+      const list = document.getElementById('badgesList')!;
+      m.badges.forEach((b: string) => {
         const span = document.createElement('span');
         span.className = 'text-xs px-3 py-1.5 rounded-full bg-navy-light text-navy border border-navy/20 font-medium';
         span.textContent = BADGE_LABELS[b] || b;
@@ -128,9 +155,9 @@ const BADGE_LABELS: Record<string, string> = {
     }
 
     if (m.interests && m.interests.length > 0) {
-      document.getElementById('interestsCard').classList.remove('hidden');
-      const list = document.getElementById('interestsList');
-      m.interests.forEach(i => {
+      document.getElementById('interestsCard')!.classList.remove('hidden');
+      const list = document.getElementById('interestsList')!;
+      m.interests.forEach((i: string) => {
         const span = document.createElement('span');
         span.className = 'text-xs px-3 py-1.5 rounded-full bg-[#F7F7F6] text-gray-600 border border-border';
         span.textContent = i;


### PR DESCRIPTION
Puts the actual coin-medallion badge design (from the design iteration: https://claude.ai/code/artifact/639aefa6-a07b-4132-861f-1fb48e664f66) onto the site, reading the `rank`/`achievement_badges` fields already returned by /api/me since #19.

**Where it shows up:**
- `/account` (own profile) — rank medallion + Pipeline badge shelf
- `/members/[username]` (public profile) — same, rank badge next to the header
- `/members` (directory) — small 48px rank badge per card

**New:** `src/lib/badges.ts` — shared client-side SVG renderer, reusing the exact icon/color/label data from the design artifact (reeded edge, bilingual curved legend, 48px floor — 32px was tested and rejected for legibility).

**Backend:** `functions/api/members.ts` and `functions/api/members/[username].ts` now also return `rank` and `achievement_badges`, same pattern already used there for the existing `badges`/`interests` fields.

**Bug found and fixed along the way:** Astro's `define:vars` forces a script to run as a classic (non-module) script, which silently breaks on ESM `import` — that's why the badges didn't render on first attempt, and it turns out it also meant these three pages' existing script logic was never actually type-checked. Fixed by dropping `define:vars`, which surfaced ~80 pre-existing strict-mode issues (missing non-null assertions, implicit-any params) in code I didn't originally write; fixed those too rather than leave the noise. Net new error count vs main: +2, matching this repo's existing `@cloudflare/workers-types`-missing pattern already present everywhere else (confirmed by diffing error counts against a clean main checkout).

**Not done here:** Turkish mirror pages (tr/account, tr/members, tr/members/profile) don't have this wired in yet.

Verified: `npm run build` succeeds, badge module confirmed present in the built JS bundle.