### PR TITLE
Render Growth rank and Pipeline badges on the Turkish pages

### DIFF
--- a/src/pages/tr/account/index.astro
+++ b/src/pages/tr/account/index.astro
@@ -1,13 +1,5 @@
 ---
 import BaseLayout from '../../../layouts/BaseLayout.astro';
-
-const BADGE_LABELS: Record<string, string> = {
-  open_to_work:        'İş / Staj Arıyor',
-  open_to_collaborate: 'Proje İşbirliğine Açık',
-  open_to_mentor:      'Mentorluk Yapmaya Açık',
-  seeking_mentor:      'Mentor Arıyor',
-  open_to_review:      'Makale / Kod Değerlendirmeye Açık',
-};
 ---
 
 <BaseLayout pageTitle="Profilim — RSG Türkiye" description="RSG Türkiye üye profiliniz.">
@@ -64,6 +56,21 @@ const BADGE_LABELS: Record<string, string> = {
           </div>
         </div>
 
+        <!-- Rank -->
+        <div id="rankCard" class="hidden bg-white rounded-2xl border border-border shadow-sm p-6 flex items-center gap-5">
+          <div id="rankBadgeWrap"></div>
+          <div>
+            <h2 class="text-sm font-semibold text-navy mb-1">Gelişim Rütbesi</h2>
+            <p id="rankDesc" class="text-sm text-gray-500"></p>
+          </div>
+        </div>
+
+        <!-- Achievement badges -->
+        <div id="achievementsCard" class="hidden bg-white rounded-2xl border border-border shadow-sm p-6">
+          <h2 class="text-sm font-semibold text-navy mb-3">Pipeline rozetleri</h2>
+          <div id="achievementsList" class="flex flex-wrap gap-4"></div>
+        </div>
+
         <!-- Status badges -->
         <div id="badgesCard" class="hidden bg-white rounded-2xl border border-border shadow-sm p-6">
           <h2 class="text-sm font-semibold text-navy mb-3">Durum</h2>
@@ -100,12 +107,32 @@ const BADGE_LABELS: Record<string, string> = {
   </div>
 </BaseLayout>
 
-<script define:vars={{ BADGE_LABELS }}>
+<script>
+  import { rankBadgeSvg, achievementBadgeSvg, achievementLabel } from '../../../lib/badges.ts';
+
+  // define:vars forces a script to run as a classic (non-module) script, which
+  // can't use `import` -- so this stays a plain static-object literal here
+  // instead, kept in sync with the frontmatter copy above by hand (it's tiny).
+  const BADGE_LABELS: Record<string, string> = {
+    open_to_work: 'İş / Staj Arıyor',
+    open_to_collaborate: 'Proje İşbirliğine Açık',
+    open_to_mentor: 'Mentorluk Yapmaya Açık',
+    seeking_mentor: 'Mentor Arıyor',
+    open_to_review: 'Makale / Kod Değerlendirmeye Açık',
+  };
+
+  const RANK_DESCRIPTIONS: Record<string, string> = {
+    seed: 'Yeni başlıyorsun.',
+    sprout: 'Öğrenme yollarında düzenli ilerliyorsun.',
+    sapling: 'Bağımsız ve derin bir ilerleme -- artık kendi başına öğreniyorsun.',
+    legacy_tree: 'Sadece tamamladıkların için değil, topluluğa geri verdiğin için tanındın.',
+  };
+
   (async () => {
-    const loading = document.getElementById('loadingState');
-    const notLoggedIn = document.getElementById('notLoggedIn');
-    const noProfile = document.getElementById('noProfile');
-    const profileContent = document.getElementById('profileContent');
+    const loading = document.getElementById('loadingState')!;
+    const notLoggedIn = document.getElementById('notLoggedIn')!;
+    const noProfile = document.getElementById('noProfile')!;
+    const profileContent = document.getElementById('profileContent')!;
 
     try {
       const res = await fetch('/api/me');
@@ -128,8 +155,8 @@ const BADGE_LABELS: Record<string, string> = {
       const p = data.profile;
 
       // Avatar
-      const avatarWrap = document.getElementById('avatarWrap');
-      const avatarFallback = document.getElementById('avatarFallback');
+      const avatarWrap = document.getElementById('avatarWrap')!;
+      const avatarFallback = document.getElementById('avatarFallback')!;
       if (p.avatar_url) {
         avatarWrap.innerHTML = `<img src="${p.avatar_url}" alt="${p.display_name}" class="w-20 h-20 rounded-full object-cover" />`;
       } else {
@@ -137,34 +164,55 @@ const BADGE_LABELS: Record<string, string> = {
       }
 
       // Basic info
-      document.getElementById('displayName').textContent = p.display_name;
-      document.getElementById('usernameEl').textContent = '@' + p.username;
+      document.getElementById('displayName')!.textContent = p.display_name;
+      document.getElementById('usernameEl')!.textContent = '@' + p.username;
 
       if (p.institution) {
-        const el = document.getElementById('institutionEl');
+        const el = document.getElementById('institutionEl')!;
         el.textContent = p.institution;
         el.classList.remove('hidden');
       }
 
       if (p.bio) {
-        const el = document.getElementById('bioEl');
+        const el = document.getElementById('bioEl')!;
         el.textContent = p.bio;
         el.classList.remove('hidden');
       }
 
       // Member badge
       if (data.user.is_member) {
-        document.getElementById('memberBadge').classList.remove('hidden');
+        document.getElementById('memberBadge')!.classList.remove('hidden');
       } else {
-        document.getElementById('membershipCta').classList.remove('hidden');
+        document.getElementById('membershipCta')!.classList.remove('hidden');
+      }
+
+      // Growth rank
+      const rank = data.rank || 'seed';
+      document.getElementById('rankCard')!.classList.remove('hidden');
+      document.getElementById('rankBadgeWrap')!.innerHTML = rankBadgeSvg(rank, 64);
+      document.getElementById('rankDesc')!.textContent = RANK_DESCRIPTIONS[rank] || '';
+
+      // Pipeline achievement badges
+      if (data.achievement_badges && data.achievement_badges.length > 0) {
+        const card = document.getElementById('achievementsCard')!;
+        const list = document.getElementById('achievementsList')!;
+        card.classList.remove('hidden');
+        data.achievement_badges.forEach((code: string) => {
+          const svg = achievementBadgeSvg(code, 56);
+          if (!svg) return;
+          const wrap = document.createElement('div');
+          wrap.className = 'flex flex-col items-center gap-1.5';
+          wrap.innerHTML = svg + `<span class="text-xs text-gray-500 text-center max-w-[80px]">${achievementLabel(code)}</span>`;
+          list.appendChild(wrap);
+        });
       }
 
       // Status badges
       if (data.badges && data.badges.length > 0) {
-        const card = document.getElementById('badgesCard');
-        const list = document.getElementById('badgesList');
+        const card = document.getElementById('badgesCard')!;
+        const list = document.getElementById('badgesList')!;
         card.classList.remove('hidden');
-        data.badges.forEach(badge => {
+        data.badges.forEach((badge: string) => {
           const span = document.createElement('span');
           span.className = 'text-xs px-3 py-1.5 rounded-full bg-navy-light text-navy border border-navy/20 font-medium';
           span.textContent = BADGE_LABELS[badge] || badge;
@@ -174,10 +222,10 @@ const BADGE_LABELS: Record<string, string> = {
 
       // Interests
       if (data.interests && data.interests.length > 0) {
-        const card = document.getElementById('interestsCard');
-        const list = document.getElementById('interestsList');
+        const card = document.getElementById('interestsCard')!;
+        const list = document.getElementById('interestsList')!;
         card.classList.remove('hidden');
-        data.interests.forEach(interest => {
+        data.interests.forEach((interest: string) => {
           const span = document.createElement('span');
           span.className = 'text-xs px-3 py-1.5 rounded-full bg-[#F7F7F6] text-gray-600 border border-border';
           span.textContent = interest;

--- a/src/pages/tr/members.astro
+++ b/src/pages/tr/members.astro
@@ -67,22 +67,35 @@ const BADGE_LABELS: Record<string, string> = {
   </div>
 </BaseLayout>
 
-<script define:vars={{ BADGE_LABELS }}>
+<script>
+  import { rankBadgeSvg } from '../../lib/badges.ts';
+
+  // define:vars forces a script to run as a classic (non-module) script, which
+  // can't use `import` -- so this stays a plain static-object literal here
+  // instead, kept in sync with the frontmatter copy above by hand (it's tiny).
+  const BADGE_LABELS: Record<string, string> = {
+    open_to_work: 'İş / Staj Arıyor',
+    open_to_collaborate: 'Proje İşbirliğine Açık',
+    open_to_mentor: 'Mentorluk Yapmaya Açık',
+    seeking_mentor: 'Mentor Arıyor',
+    open_to_review: 'Makale / Kod Değerlendirmeye Açık',
+  };
+
   const LIMIT = 24;
   let offset = 0;
   let isLoading = false;
   let hasMore = false;
-  let searchTimer;
+  let searchTimer: ReturnType<typeof setTimeout>;
 
   function getFilters() {
     return {
-      search: document.getElementById('searchInput').value.trim(),
-      interest: document.getElementById('interestFilter').value,
-      badge: document.getElementById('badgeFilter').value,
+      search: (document.getElementById('searchInput')! as HTMLInputElement).value.trim(),
+      interest: (document.getElementById('interestFilter')! as HTMLSelectElement).value,
+      badge: (document.getElementById('badgeFilter')! as HTMLSelectElement).value,
     };
   }
 
-  function avatarHtml(member) {
+  function avatarHtml(member: any) {
     if (member.avatar_url) {
       return `<img src="${member.avatar_url}" alt="${member.display_name}" class="w-14 h-14 rounded-full object-cover" />`;
     }
@@ -90,12 +103,12 @@ const BADGE_LABELS: Record<string, string> = {
     return `<div style="width:56px;height:56px;border-radius:50%;background:#e8edf5;display:flex;align-items:center;justify-content:center;font-size:20px;font-weight:700;color:#0f2045;">${initial}</div>`;
   }
 
-  function renderCard(member) {
-    const badges = (member.badges || []).slice(0, 2).map(b =>
+  function renderCard(member: any) {
+    const badges = (member.badges || []).slice(0, 2).map((b: string) =>
       `<span style="font-size:11px;padding:3px 10px;border-radius:99px;background:#e8edf5;color:#0f2045;font-weight:500;">${BADGE_LABELS[b] || b}</span>`
     ).join('');
 
-    const interests = (member.interests || []).slice(0, 3).map(i =>
+    const interests = (member.interests || []).slice(0, 3).map((i: string) =>
       `<span style="font-size:11px;padding:3px 10px;border-radius:99px;background:#f3f4f6;color:#6b7280;border:1px solid #e5e7eb;">${i}</span>`
     ).join('');
 
@@ -115,6 +128,7 @@ const BADGE_LABELS: Record<string, string> = {
             <div style="font-size:12px;color:#9ca3af;margin-top:2px;">@${member.username}</div>
             ${member.institution ? `<div style="font-size:12px;color:#6b7280;margin-top:2px;">${member.institution}</div>` : ''}
           </div>
+          <div style="flex-shrink:0;">${rankBadgeSvg(member.rank || 'seed', 48)}</div>
         </div>
         ${member.bio ? `<p style="font-size:13px;color:#6b7280;line-height:1.5;margin-bottom:10px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;">${member.bio}</p>` : ''}
         ${badges ? `<div style="display:flex;flex-wrap:wrap;gap:5px;margin-bottom:8px;">${badges}</div>` : ''}
@@ -128,14 +142,14 @@ const BADGE_LABELS: Record<string, string> = {
 
     if (reset) {
       offset = 0;
-      document.getElementById('memberGrid').innerHTML = '';
-      document.getElementById('memberGrid').classList.add('hidden');
-      document.getElementById('emptyState').classList.add('hidden');
-      document.getElementById('loadingState').classList.remove('hidden');
+      document.getElementById('memberGrid')!.innerHTML = '';
+      document.getElementById('memberGrid')!.classList.add('hidden');
+      document.getElementById('emptyState')!.classList.add('hidden');
+      document.getElementById('loadingState')!.classList.remove('hidden');
     }
 
     const { search, interest, badge } = getFilters();
-    const params = new URLSearchParams({ limit: LIMIT, offset });
+    const params = new URLSearchParams({ limit: String(LIMIT), offset: String(offset) });
     if (search) params.set('search', search);
     if (interest) params.set('interest', interest);
     if (badge) params.set('badge', badge);
@@ -143,23 +157,23 @@ const BADGE_LABELS: Record<string, string> = {
     const res = await fetch(`/api/members?${params}`);
     const data = await res.json();
 
-    document.getElementById('loadingState').classList.add('hidden');
+    document.getElementById('loadingState')!.classList.add('hidden');
 
-    const grid = document.getElementById('memberGrid');
+    const grid = document.getElementById('memberGrid')!;
     const members = data.members || [];
     hasMore = members.length === LIMIT;
     offset += members.length;
 
     if (reset && members.length === 0) {
-      document.getElementById('emptyState').classList.remove('hidden');
+      document.getElementById('emptyState')!.classList.remove('hidden');
     } else {
       grid.classList.remove('hidden');
-      members.forEach(m => {
+      members.forEach((m: any) => {
         grid.insertAdjacentHTML('beforeend', renderCard(m));
       });
     }
 
-    document.getElementById('loadMoreBtn').classList.toggle('hidden', !hasMore);
+    document.getElementById('loadMoreBtn')!.classList.toggle('hidden', !hasMore);
     isLoading = false;
   }
 
@@ -175,11 +189,11 @@ const BADGE_LABELS: Record<string, string> = {
   })();
 
   // Search & filters
-  document.getElementById('searchInput').addEventListener('input', () => {
+  document.getElementById('searchInput')!.addEventListener('input', () => {
     clearTimeout(searchTimer);
     searchTimer = setTimeout(() => loadMembers(true), 350);
   });
-  document.getElementById('interestFilter').addEventListener('change', () => loadMembers(true));
-  document.getElementById('badgeFilter').addEventListener('change', () => loadMembers(true));
-  document.getElementById('loadMoreBtn').addEventListener('click', () => loadMembers(false));
+  document.getElementById('interestFilter')!.addEventListener('change', () => loadMembers(true));
+  document.getElementById('badgeFilter')!.addEventListener('change', () => loadMembers(true));
+  document.getElementById('loadMoreBtn')!.addEventListener('click', () => loadMembers(false));
 </script>


### PR DESCRIPTION
Follow-up to #20 -- that PR only covered the English pages (account/index.astro, members.astro, members/profile.astro) and explicitly called out the Turkish mirrors as not done yet. This PR covers the two that exist:

- tr/account/index.astro -- rank medallion + Pipeline badge shelf (translated: 'Gelişim Rütbesi', 'Pipeline rozetleri', rank descriptions in Turkish)
- tr/members.astro -- small 48px rank badge per member card

(There's no tr/members/profile.astro -- the Turkish member directory already links to the English public profile page, that's pre-existing behavior, not something this PR changes.)

Same underlying fix as #20: define:vars forces a classic script, which breaks ESM import, so it's dropped in favor of a literal BADGE_LABELS object; that also surfaced this file's own type errors for the first time, fixed alongside.

Verified: npm run build succeeds, both pages' scripts confirmed as proper module bundles in the build output, npx astro check shows zero new errors in either file (154 total vs main's 152 baseline, same +2 pattern as #20).