### PR TITLE
Fix logo blending into dark background on account setup pages

### DIFF
--- a/src/pages/account/setup.astro
+++ b/src/pages/account/setup.astro
@@ -23,7 +23,7 @@ const BADGES = [
 
       <!-- Header -->
       <div class="text-center mb-10">
-        <div class="inline-flex items-center justify-center w-14 h-14 rounded-full bg-navy mb-4">
+        <div class="inline-flex items-center justify-center w-14 h-14 rounded-full bg-white border border-border shadow-sm mb-4">
           <img src="/logo/rsgturkey_logo.png" alt="" width="40" height="40" class="rounded p-0.5" />
         </div>
         <h1 class="text-2xl font-bold text-navy mb-2">Set up your profile</h1>

--- a/src/pages/tr/account/setup.astro
+++ b/src/pages/tr/account/setup.astro
@@ -23,7 +23,7 @@ const BADGES = [
 
       <!-- Header -->
       <div class="text-center mb-10">
-        <div class="inline-flex items-center justify-center w-14 h-14 rounded-full bg-navy mb-4">
+        <div class="inline-flex items-center justify-center w-14 h-14 rounded-full bg-white border border-border shadow-sm mb-4">
           <img src="/logo/rsgturkey_logo.png" alt="" width="40" height="40" class="rounded p-0.5" />
         </div>
         <h1 class="text-2xl font-bold text-navy mb-2">Profilinizi oluşturun</h1>


### PR DESCRIPTION
The logo circle on /account/setup and /tr/account/setup used `bg-navy`, but the logo image expects a white backdrop to actually be visible (same as Header.astro and the footer, which both already put `bg-white` on the img itself). On navy, the logo's transparent/dark parts blended into the background and were hard to see.

Fix: changed the circle to `bg-white` with a subtle border/shadow (matching the site's existing card styling) so it reads as a proper logo badge against the page's light-gray background instead of just disappearing.

Same bug existed on both language versions, fixed both.

Verified: npm run build succeeds.