### PR TITLE
Translate 5 most recent blog posts to Turkish (#6, batch 1 of ~9)

### DIFF
--- a/src/content/blog/tr/bioinformatics-where-to-start.md
+++ b/src/content/blog/tr/bioinformatics-where-to-start.md
@@ -1,0 +1,67 @@
+---
+title: "Biyoinformatik: Nereden Başlamalı?"
+pubDate: 2024-07-05
+description: "Biyoinformatik ve hesaplamalı biyoloji alanına nasıl gireceğini merak eden herkes için başlangıç dostu bir kaynak rehberi."
+author: RSG Turkiye
+category: general
+tags: ["beginners", "resources", "learning"]
+image: ""
+lang: "tr"
+draft: false
+---
+
+Biyoinformatikte başlangıç yapmak bunaltıcı hissettirebilir — çok fazla kaynak, çok fazla yön ve net bir giriş noktası yok. Bu rehber, yeni başlayan öğrenciler için beceri alanına göre düzenlenmiş önerileri bir araya getiriyor.
+
+## Temel Beceri Alanları
+
+### Programlama ve Unix Ortamı
+
+Biyoinformatiğe özgü araçlara dalmadan önce, kodlamaya alışmak esastır. Çoğu biyoinformatik iş akışı Unix/Linux sistemlerinde çalışır, bu yüzden komut satırına (shell, Ubuntu, uzak sunucular) aşinalık neredeyse her şey için bir ön koşuldur.
+
+Geçmişiniz yaşam bilimlerindeyse buradan başlayın:
+- Temel Python veya R öğrenin — laboratuvarınız hangisini kullanıyorsa
+- Terminale alışın: dosya gezinme, metin işleme, script çalıştırma
+- Sürüm kontrolü için **Git**, çalışmanızı paylaşmak için **GitHub** kullanın — küçük kişisel projeler bile iyi bir pratiktir
+
+Temelleri edindikten sonra, yaygın analiz iş akışlarını sıfırdan yeniden icat etmemek için [Nextflow](https://www.nextflow.io/) veya [Snakemake](https://snakemake.readthedocs.io/) gibi **iş akışı sistemlerini** keşfedin.
+
+### İstatistik ve Olasılık
+
+Biyoinformatiğin her seviyesinde sağlam bir istatistik anlayışına ihtiyaç vardır. Yaşam bilimleri okuduysanız muhtemelen bir temeliniz vardır — amaç bunun üzerine inşa etmektir.
+
+[Josh (StatQuest) Starmer'ın YouTube kanalı](https://www.youtube.com/channel/UCtYLUTtgS3k1Fg4y5tAhLbw), mevcut en iyi ücretsiz kaynaklardan biridir: temel istatistikten makine öğrenmesine kadar her şeyi sıfırdan, açık bir şekilde anlatır.
+
+### Video Kaynakları ve Topluluk Sayfaları
+
+Bu YouTube kanalları, ister tam bir yeni başlayan olun ister zaten ileri düzey analizler yapıyor olun faydalıdır:
+
+- [chatomics](https://www.youtube.com/@chatomics) — Tommy'nin pratik eğitimleri
+- [Bioinformagician](https://www.youtube.com/@Bioinformagician) — rehberli anlatımlar
+- [SIB Swiss Institute of Bioinformatics](https://www.youtube.com/c/SIBSwissInstituteofBioinformatics) — yapılandırılmış kurslar ve seminerler
+
+[Harvard Chan Bioinformatics Core (hbctraining)](https://github.com/hbctraining) GitHub sayfaları da mükemmeldir — kurslarından tam eğitim materyallerini içerirler.
+
+### Kendi Kendine Öğrenim Müfredatı
+
+Daha yapılandırılmış bir yaklaşım için, [OSSU Bioinformatics](https://github.com/ossu/bioinformatics) tüm beceri yelpazesini kapsayan, kendi hızınızda ilerleyebileceğiniz açık bir müfredat sunar. Bağlantılı kaynakların çoğu ücretsizdir.
+
+## Nasıl Bir Biyoinformatikçi Olmak İstiyorsunuz?
+
+Bu alan geniştir. İşte ana rollerin kaba bir haritası:
+
+1. **Algoritma geliştiricileri** — İleri matematik ve istatistiği kodla birleştirirler. Genellikle güçlü teorik altyapıya sahip Bilgisayar Mühendisliği mezunlarıdır.
+2. **Araç geliştiricileri** — Daha çok yazılım mühendisliğine odaklıdırlar. Mevcut algoritmaların üzerine kullanıcı dostu araçlar inşa eder ve erişimlerini genişletirler.
+3. **Uygulamalı analistler** — Güçlü bir biyoloji altyapısına sahiptirler, yaşam bilimleri araştırmalarını ilerletmek için mevcut araçları kullanır ve uyarlarlar. Alana giren çoğu biyolog burada son bulur.
+4. **Islak laboratuvar + araçlar** — Kodun derinine inmeden veri analizi için belirli çevrimiçi veya çevrimdışı araçlar kullanan deneysel araştırmacılar.
+
+Bu gruplar arasında keskin bir çizgi yoktur ve çoğu insan zamanla aralarında hareket eder. Nereden başlamak istediğinizi bilmek, önce neyi öğreneceğinizi seçmenize yardımcı olur.
+
+## Topluluklar ve Motivasyonu Korumak
+
+Biyoinformatiğin öğrenme eğrisi yüksektir. Gerçek projeler üzerinde çalışmak — özellikle bir mentorla — sadece eğitimleri takip etmekten çok daha hızlı ilerleme sağlar.
+
+Bir topluluğun parçası olmak motivasyona yardımcı olur. RSG Türkiye, ücretsiz eğitim etkinlikleri düzenler ve Türkiye genelinde biyoinformatik ve hesaplamalı biyoloji ile ilgilenen öğrencileri birbirine bağlar. Yaklaşan etkinlikler ve geçmiş materyaller için [GitHub](https://github.com/rsgturkey) sayfamıza göz atın.
+
+Sorularınız ve sorun giderme için [Biostars](https://www.biostars.org/) ve Stack Overflow en güvenilir topluluk kaynakları olmaya devam ediyor. Yapay zeka asistanları (örneğin ChatGPT) da hızlı açıklamalar ve hata ayıklama için faydalı olabilir — ancak özellikle özel araçlar için çıktılarını doğrulayın.
+
+**Bu alandaki çoğu beceri pratikle olgunlaşır.** Küçük bir proje seçin, analizler çalıştırmaya başlayın, hatalar yapın ve düzeltin. En hızlı ilerleme yolu budur.

--- a/src/content/blog/tr/from-biological-big-data-to-meaningful-information-bioinformatics-and-its-applications.md
+++ b/src/content/blog/tr/from-biological-big-data-to-meaningful-information-bioinformatics-and-its-applications.md
@@ -1,0 +1,107 @@
+---
+title: "Biyolojik Büyük Veriden Anlamlı Bilgiye: Biyoinformatik ve Uygulamaları"
+pubDate: 2025-08-07
+description: "Bilgisayar algoritmaları kullanarak protein yapılarını dakikalar içinde tahmin edebildiğimizi duymuş olabilirsiniz. Bu teknolojiler ortaya çıkmadan önce, protein..."
+author: Zeynep Vurat
+category: general
+tags: ["2025-webinars"]
+image: ""
+lang: "tr"
+draft: false
+---
+
+Bilgisayar algoritmaları kullanarak protein yapılarını dakikalar içinde tahmin edebildiğimizi duymuş olabilirsiniz. Bu teknolojiler ortaya çıkmadan önce, protein yapılarını tahmin etmek laboratuvarda yıllar süren yorucu bir çalışma gerektiriyordu. Peki işimizi bu kadar kolaylaştıran şey ne değişti? Hesaplamalı yöntemler ve gelişmiş algoritmalar sayesinde, artık genetik bilgimize dayanarak hastalıklarımıza özgü tedavi planlarını kişiselleştirmek mümkün görünüyor. Bu gelişmeler ayrıca maliyetli ve uzun süren ilaç keşif süreçlerinin maliyetini düşürmemizi de sağlıyor.
+
+Günümüzde üretilen biyolojik veri miktarı her geçen gün katlanarak artıyor. 2003 yılında İnsan Genom Projesi'nin tamamlanmasıyla başlayan bu veri üretim süreci, benzeri görülmemiş miktarda biyolojik büyük verinin birikmesine yol açtı ve bu da veriyi düzenleme ve yorumlama konusunda zorluklar yarattı\[1\]. Bu devasa veri setlerinin yorumlanması, hesaplamalı yaklaşımların kullanılmasıyla mümkün hale geldi ve böylece biyoinformatik alanı doğdu\[1\].
+
+**Biyoinformatik Nedir**
+
+Biyoinformatik; biyoloji, tıp bilimleri, bilgi teknolojileri, matematik ve biyoistatistiğin sentezi sonucunda ortaya çıkan, biyolojik verinin elde edilmesi ve yorumlanması için hesaplamalı ve analitik araçlar kullanan çok disiplinli bir bilim alanıdır. Kısacası biyoinformatik, biyolojik veriyi bilgisayarlar aracılığıyla inceleme ve anlama bilimidir.
+
+**Biyoinformatiğin amaçları aşağıdaki üç başlık altında özetlenebilir:**
+
+1\. Veri düzenleme
+
+2\. Sistem geliştirme
+
+3\. Sistem uygulama\[2\]
+
+**Veri düzenleme**, biyolojik veriyi (DNA, protein dizileri vb.) kolay erişilebilir hale getirmek ve bu amaçla basit veritabanları oluşturmak için düzenlemeyi hedefler. Bu, araştırmacıların veriye kolayca erişmesini ve gerektiğinde yeni sonuçlarını bu veritabanına aktarmasını sağlar\[2\].
+
+Veriyi düzenlemek amacıyla kurulan ilk biyolojik dizi veritabanı, Margaret Dayhoff tarafından 1972'de kurulan 'Protein Identification Resource'tu. Sonraki yıllarda ilk DNA veritabanı da kuruldu. Günümüzde internet üzerinden ücretsiz erişilebilen sayısız veritabanı bulunuyor. DNA dizileri için en önemli veritabanları GenBank, EMBL ve DDBJ'dir\[3\].
+
+Protein verisini düzenleme ve sunma konusuna gelince, dünya çapında birçok protein bankası bulunuyor. Bunların en önemlileri SwissProt, PIR International ve Protein DataBank (PDB) protein bankalarıdır.
+
+**Sistemlerin geliştirilmesi**, toplanan biyolojik veriyi anlamak ve yorumlamak için çeşitli yazılım, algoritma ve yöntemlerin geliştirilmesini ifade eder. Yapısı ve içeriği oldukça büyük ve karmaşık olan biyolojik veriyi analiz etmek için araç ve kaynakların geliştirilmesine odaklanır\[2\].
+
+Analiz edilen bir proteinin dizisini daha önce karakterize edilmiş dizilerle karşılaştırmak için geliştirilen algoritmalar, biyoinformatiğin bu hedefine bir örnektir. Bu algoritmalar, diziler arasındaki homolog bölgelerin tespit edilmesini sağlar.
+
+Günümüzde yaygın olarak kullanılan BLAST, büyük veritabanlarında protein veya DNA dizilerini hızlıca karşılaştırıp benzer dizileri bulmak için en yaygın ve temel araçtır. ClustalW de yaygın olarak kullanılan araçlardan biridir.
+
+**Bu sistemlerin uygulanması**, geliştirilen yöntem ve araçları kullanarak gerçek biyolojik problemlerin anlamlı bir şekilde analiz edilmesini ve yorumlanmasını içerir\[2\].
+
+Farklı veri türleri içeren çeşitli veritabanları mevcuttur. En yaygın kullanılan veritabanlarının bir listesine erişmek için bu bağlantıyı takip edebilirsiniz.
+
+**Biyoinformatiğin Uygulamaları Nelerdir?**
+
+Biyoinformatik uygulamaları geniş anlamda üç ana teknik altında sınıflandırılabilir: dizi analizi, yapısal analiz ve fonksiyonel analiz. Bu teknikler dahilinde, biyoinformatiğin temel uygulama alanları genomik ve proteomik eksenleri boyunca gelişmiştir.
+
+**Genomik Uygulamalar**
+
+Genomik, farklı türlere ait genomların tüm yapısal ve fonksiyonel yönlerini inceleyen bir biyoinformatik uygulama alanıdır. Bu alandaki öne çıkan uygulamalar şunlardır:
+
+**Genom Dizileme ve Karşılaştırma:** Çeşitli organizmaların genomlarını dizileyerek ve genomlar arasındaki dizi benzerliklerini belirleyerek, organizmaların genetik yapısı anlaşılabilir. Bu, genetik varyasyonların tespit edilmesini sağlayarak kanser, kalp hastalığı ve diyabet gibi hastalıklar için daha etkili tedavilerin geliştirilmesine olanak tanır\[4\].
+
+**Gen Fonksiyon Analizi:** Genler, fonksiyonlarına göre tanımlanabilir ve sınıflandırılabilir\[4\]. Örneğin, bağışıklık sistemini düzenlemede rol oynayan genlerin belirlenmesiyle, romatoid artrit, lupus ve multipl skleroz gibi otoimmün hastalıklar için tedaviler geliştirilebilir\[4\].
+
+**Gen Ekspresyon Analizi:** Gen ekspresyon verilerini analiz ederek, genlerin hücre ve dokularda nasıl düzenlendiği anlaşılabilir\[4\]. Kanser hastalarından elde edilen gen ekspresyon verilerini analiz ederek, kanser hücrelerindeki gen ekspresyon düzeyleri normal hücrelerle karşılaştırılabilir ve biyobelirteçler geliştirilebilir\[4\].
+
+**Proteomik Uygulamalar**
+
+Proteomik analizler, amino asit dizilerine dayanarak proteinlerin yapı ve fonksiyonunu tahmin etmek için kullanılır. Biyoinformatik araçlar bir protein molekülünün 3 boyutlu yapısını tahmin edebilir, bu da araştırmacıların HIV, Alzheimer ve kanser gibi hastalıklarda rol oynayan spesifik proteinleri hedef alan ilaçlar tasarlamasına yardımcı olur\[4\].
+
+**Diğer Uygulama Alanları**
+
+Genomik ve proteomiğe ek olarak, biyoinformatiğin diğer önemli uygulama alanları şunları içerir:
+
+● **Transkriptomik, Metabolomik ve Epidemiyoloji:** Bu omik alanları da biyoinformatiğin temel uygulama alanlarındandır.
+
+● **Rasyonel İlaç Keşfi:** Potansiyel ilaç hedeflerini belirlemek ve yeni ilaçlar tasarlamak için kullanılır. Biyoinformatik, ilaç keşif sürecini hızlandırarak daha düşük maliyetli ve hedefe yönelik ilaç tasarımını mümkün kılar\[5\].
+
+**● Klinik Biyoinformatik (Kişiselleştirilmiş Tıp):** Her bireyin kendine özgü genetik yapısı, çevresel faktörleri ve yaşam tarzı göz önünde bulundurularak tıbbi tedavi ve önleme stratejileri geliştirilir\[5\].
+
+● **Tarım ve Gıda:** Ürün verimini artırmak ve yeni ürün çeşitleri geliştirmek için biyoinformatik teknikleri kullanılır\[5\].
+
+**Biyoinformatiğin Geleceği**
+
+Biyoinformatiğin geleceği, teknolojik gelişmelerle birlikte oldukça umut verici görünüyor. Bu alandaki öne çıkan gelişmeler şunlardır:
+
+**Yapay Zeka Entegrasyonu**
+
+Yapay zeka ve makine öğrenmesi algoritmaları, birçok biyoinformatik sürecin özerk bir şekilde gerçekleştirilmesini sağlayarak karmaşık biyolojik bilginin analizinde zaman ve emek tasarrufu sağlıyor. Bunun bir örneği, son yıllarda geliştirilen AlphaFold'dur. Yapay zeka ile entegre bir biyoinformatik aracı olan AlphaFold, ellerindeki dizilerden protein yapılarını tahmin ederek araştırmacılara hızlı ve etkili bir kullanım sunuyor. Benzer şekilde, yapay zeka kişiselleştirilmiş tıp ve ilaç keşfi süreçlerine de entegre edilerek tedavi stratejilerinin daha öngörülebilir ve etkili olmasını sağlıyor\[6\].
+
+**Çoklu-Omik Veri Entegrasyonu**
+
+Sistem biyolojisi olarak da bilinen bu yaklaşım, farklı biyolojik sistemlerin bir bütün olarak nasıl işlediğini anlamak için genomik, proteomik ve metabolomik gibi birden fazla 'omik' disiplininden gelen bilgilerin entegre edilmesini içerir. Bu entegrasyon, biyolojik sistemlerin karmaşıklığını anlamak için hayati önem taşıyor\[7\].
+
+Gelecekte bir bireyin dijital ikizinin oluşturulabileceğini öne süren devam eden çalışmalar var. Gen ekspresyonu, hücresel yolaklar ve moleküler etkileşimleri deneysel ve hesaplamalı yöntemlerle entegre ederek, hücresel ve organ düzeyinde dijital ikizler yaratmanın mümkün olduğu düşünülüyor\[8\].
+
+Biyolojik verinin hacmi ve karmaşıklığı artmaya devam ettikçe, biyoinformatiğin önemi de artmaya devam edecek. Bu yenilikler yalnızca biyoloji anlayışımızı geliştirmeyi vaat etmiyor, aynı zamanda sağlık hizmetlerini, kişiselleştirilmiş tıbbı ve ilaç geliştirmeyi yeniden şekillendirme potansiyeline de sahip.
+
+**Kaynakça**
+
+\[1\] Vincent, A. T., & Charette, S. J. (2015). Who qualifies to be a bioinformatician?. Frontiers in genetics, 6, 164. [https://doi.org/10.3389/fgene.2015.00164](https://doi.org/10.3389/fgene.2015.00164)
+
+\[2\] Polat M, Karahan A. Multidisipliner Yeni Bir Bilim Dalı: Biyoinformatik ve Tıpta Uygulamaları. Med J SDU. 2009;16(3):41-50.
+
+\[3\] Guenter Stoesser, Mary Ann Moseley, Joanne Sleep, Michael McGowran, Maria Garcia-Pastor, Peter Sterk, The EMBL Nucleotide Sequence Database, _Nucleic Acids Research_, Volume 26, Issue 1, 1 January 1998, Pages 8–15, [https://doi.org/10.1093/nar/26.1.8](https://doi.org/10.1093/nar/26.1.8)
+
+\[4\]"Applications of Bioinformatics in Various Fields." BioinformaticsHome, [https://bioinformaticshome.com/bioinformatics\_tutorials/Applications%20of%20bioinformatics.html](https://bioinformaticshome.com/bioinformatics_tutorials/Applications%20of%20bioinformatics.html). Accessed 24 April 2025.
+
+\[5\] Karazhanov D (2023) Techniques Involved in Bioinformatics and their Applications in the Field of Genomics. Int J Adv Technol. 14:226.
+
+\[6\] Jumper, J., Evans, R., Pritzel, A. _et al._ Highly accurate protein structure prediction with AlphaFold. _Nature_ **596**, 583–589 (2021). https://doi.org/10.1038/s41586-021-03819-2
+
+\[7\] "Bioinformatics: Key Techniques, Applications, and Future Trends in Biological Data Analysis." E-SPIN Group, [https://www.e-spincorp.com/bioinformatics-techniques-applications-future-trends/](https://www.e-spincorp.com/bioinformatics-techniques-applications-future-trends/). Accessed 28 April 2025.
+
+\[8\] Alsalloum, G. A., Al Sawaftah, N. M., Percival, K. M., & Husseini, G. A. (2024). Digital Twins of Biological Systems: A Narrative Review. _IEEE open journal of engineering in medicine and biology_, _5_, 670–677. https://doi.org/10.1109/OJEMB.2024.3426916

--- a/src/content/blog/tr/member-spotlight-dr-ayse-kaya.md
+++ b/src/content/blog/tr/member-spotlight-dr-ayse-kaya.md
@@ -1,0 +1,54 @@
+---
+title: "Üye Tanıtımı: Dr. Ayşe Kaya"
+pubDate: 2024-01-25
+description: "Hesaplamalı genomik alanında öncü bir araştırmacı ve aktif RSG Türkiye üyesi olan Dr. Ayşe Kaya ile tanışın."
+author: "RSG Turkiye Communications Team"
+category: "community"
+tags:
+  - "member-spotlight"
+  - "research"
+  - "genomics"
+  - "community"
+image: "/images/member-spotlight.jpg"
+lang: "tr"
+draft: false
+---
+
+Bu ay, hesaplamalı genomik alanında seçkin bir araştırmacı ve RSG Türkiye topluluğumuzun aktif bir üyesi olan **Dr. Ayşe Kaya**'yı tanıtmaktan mutluluk duyuyoruz.
+
+## Dr. Kaya Hakkında
+
+Dr. Kaya, İstanbul Teknik Üniversitesi'nde Yardımcı Doçent olarak görev yapmakta ve Hesaplamalı Genomik Laboratuvarı'na liderlik etmektedir. Araştırmaları, gelişmiş hesaplamalı yöntemler kullanarak karmaşık hastalıkların genetik temelini anlamaya odaklanmaktadır.
+
+## Araştırma Öne Çıkanları
+
+### Devam Eden Projeler
+
+1. **Kanser Genomiği**: Kanser biyobelirteçlerini tespit etmek için makine öğrenmesi algoritmaları geliştirme
+2. **Popülasyon Genetiği**: Türk popülasyonlarında genetik çeşitliliği inceleme
+3. **İlaç Keşfi**: İlaç-hedef etkileşimlerini tahmin etmek için hesaplamalı yöntemler kullanma
+
+### Son Yayınlar
+
+- "Machine Learning Approaches in Cancer Biomarker Discovery" (Nature Computational Science, 2023)
+- "Genetic Diversity Patterns in Anatolian Populations" (PLOS Genetics, 2023)
+- "Computational Drug Repurposing for Rare Diseases" (Bioinformatics, 2023)
+
+## RSG Türkiye'deki Katkıları
+
+Dr. Kaya, şu konularda belirleyici bir rol oynamıştır:
+
+- Yıllık sempozyumumuzu organize etmek
+- Hesaplamalı biyoloji alanında öğrencilere mentorluk yapmak
+- Genomik analizi üzerine atölyelere liderlik etmek
+- Eğitim kaynaklarımıza katkıda bulunmak
+
+## Öğrencilere Tavsiyeler
+
+> "Hesaplamalı biyoloji hızla gelişen bir alan. Meraklı olun, yeni araçlar öğrenmeye devam edin ve işbirliği yapmaktan çekinmeyin. RSG Türkiye topluluğu, ağınızı kurmaya başlamak için harika bir yer."
+
+## Gelecek Planları
+
+Dr. Kaya şu anda ulusal bir hesaplamalı biyoloji konsorsiyumu kurma çalışmaları yürütüyor ve RSG Türkiye'nin uluslararası işbirliklerini genişletmeyi umuyor.
+
+Dr. Kaya'yı topluluğumuzun bir parçası olarak gördüğümüz için gurur duyuyoruz ve Türkiye'deki hesaplamalı biyolojiye katkılarının devamını dört gözle bekliyoruz!

--- a/src/content/blog/tr/upcoming-bioinformatics-workshop-series.md
+++ b/src/content/blog/tr/upcoming-bioinformatics-workshop-series.md
@@ -1,0 +1,56 @@
+---
+title: "Yaklaşan Biyoinformatik Atölye Serisi"
+pubDate: 2024-01-20
+description: "Temel biyoinformatik araç ve tekniklerini kapsayan atölye serimize katılın."
+author: "RSG Turkiye Education Team"
+category: events
+tags:
+  - "workshop"
+  - "education"
+  - "bioinformatics"
+  - "training"
+image: "/images/workshop-series.jpg"
+lang: "tr"
+draft: false
+---
+
+**Biyoinformatik Atölye Serimizi** duyurmaktan heyecan duyuyoruz! Bu kapsamlı program, öğrenci ve araştırmacıların hesaplamalı biyolojideki temel becerileri geliştirmesine yardımcı olmak için tasarlandı.
+
+## Atölye Programı
+
+### 1. Hafta: Biyoinformatiğe Giriş
+- **Tarih**: 15 Şubat 2024
+- **Konular**: Temel kavramlar, dizi analizi ve veritabanı arama
+- **Araçlar**: BLAST, FASTA ve NCBI veritabanları
+
+### 2. Hafta: Genom Birleştirme ve Anotasyon
+- **Tarih**: 22 Şubat 2024
+- **Konular**: Birleştirme algoritmaları, kalite değerlendirmesi ve gen tahmini
+- **Araçlar**: SPAdes, QUAST ve Prokka
+
+### 3. Hafta: Transkriptomik Analizi
+- **Tarih**: 1 Mart 2024
+- **Konular**: RNA-seq veri analizi, diferansiyel ekspresyon ve görselleştirme
+- **Araçlar**: STAR, DESeq2 ve R/Bioconductor
+
+### 4. Hafta: Protein Yapısı Tahmini
+- **Tarih**: 8 Mart 2024
+- **Konular**: Homoloji modelleme, moleküler dinamik ve yapı doğrulama
+- **Araçlar**: Modeller, GROMACS ve PyMOL
+
+## Kayıt
+
+Atölyeler RSG Türkiye üyeleri için ücretsizdir. Üye olmayanlar küçük bir ücret karşılığında katılabilir. Her atölye şunları içerir:
+
+- Uygulamalı pratik oturumlar
+- Bulut bilişim kaynaklarına erişim
+- Katılım sertifikası
+- Networking fırsatları
+
+## Ön Koşullar
+
+- Temel Linux komut satırı bilgisi
+- R veya Python'a aşinalık (önerilir)
+- En az 8GB RAM'e sahip bir dizüstü bilgisayar
+
+Biyoinformatik becerilerinizi geliştirmek için bu fırsatı kaçırmayın! Yerinizi ayırtmak için hemen kayıt olun.

--- a/src/content/blog/tr/welcome-to-rsg-turkey.md
+++ b/src/content/blog/tr/welcome-to-rsg-turkey.md
@@ -1,0 +1,42 @@
+---
+title: "RSG Türkiye Blog'una Hoş Geldiniz"
+pubDate: 2024-01-15
+description: "Hesaplamalı biyoloji üzerine görüşleri ve topluluk güncellemelerini paylaşacağımız yeni blog platformumuzu tanıtıyoruz."
+author: "RSG Turkiye Team"
+category: community
+tags:
+  - "community"
+  - "bioinformatics"
+  - "computational-biology"
+  - "rsg-turkey"
+image: "/images/blog-welcome.jpg"
+lang: "tr"
+draft: false
+---
+
+**RSG Türkiye Blog'una** hoş geldiniz! Hesaplamalı biyoloji dünyasından görüşleri, araştırma güncellemelerini ve topluluk hikayelerini paylaşacağımız yeni platformumuzu duyurmaktan heyecan duyuyoruz.
+
+## Neler Paylaşacağız
+
+Blogumuzda şunlar yer alacak:
+
+1. **Araştırma Güncellemeleri**: Biyoinformatik ve hesaplamalı biyolojideki son gelişmeler
+2. **Topluluk Hikayeleri**: Üye tanıtımları ve başarı hikayeleri
+3. **Etkinlik Kapsamları**: Webinar, sempozyum ve atölyelerimizden raporlar
+4. **Eğitim İçerikleri**: Eğitici yazılar ve öğrenme kaynakları
+5. **Sektör Haberleri**: Geniş biyoinformatik topluluğundan güncellemeler
+
+## Misyonumuz
+
+ISCB Student Council'ın bir parçası olarak RSG Türkiye, Türkiye'de canlı bir hesaplamalı biyoloji topluluğu oluşturmaya kararlıdır. Bu blog aracılığıyla amacımız:
+
+- Bilgi ve görüşleri topluluğumuzla paylaşmak
+- Üyelerimizin çalışmalarını öne çıkarmak
+- Öğrenciler ve araştırmacılar için eğitim kaynakları sağlamak
+- Küresel biyoinformatik topluluğuyla bağlantı kurmak
+
+## Bağlantıda Kalın
+
+En son yazılarımızı gelen kutunuzda almak için bültenimize abone olmayı unutmayın. Ayrıca anlık güncellemeler için bizi sosyal medyada takip edebilirsiniz.
+
+Sizinle değerli içerikler paylaşmayı ve birlikte daha güçlü bir hesaplamalı biyoloji topluluğu inşa etmeyi dört gözle bekliyoruz!


### PR DESCRIPTION
First batch toward closing the EN->TR translation gap in #6 (34 blog posts + 11 webinars currently missing a Turkish version). Picked the 5 most recently published English posts as a starting batch — please check the tone/quality before I continue with the rest.

- welcome-to-rsg-turkey.md
- upcoming-bioinformatics-workshop-series.md
- member-spotlight-dr-ayse-kaya.md
- bioinformatics-where-to-start.md
- from-biological-big-data-to-meaningful-information-bioinformatics-and-its-applications.md

Same filename as the English source, title/description/body translated, date/author/category/tags/image left unchanged (per #6's rules), `lang` flipped to `tr`.

**Flagging, not translating yet:** `welcome-to-iscb-sc-rsg-turkey-s-official-website.md` and `welcome-to-iscb-sc-rsg-turkeys-official-website.md` look like near-duplicate posts (titles a letter apart, dates one day apart). Worth a human decision on whether these are genuinely two posts before either gets translated.

Verified: `npm run build` succeeds, all 5 `/tr/blog/...` pages generate with no content-schema errors.