### PR TITLE
Draft 3 webinars with dead recording links (#3)

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -54,6 +54,7 @@ const webinars = defineCollection({
     // Valid values: genomics, ml, structural, metagenomics, popgen, systems
     // Example: domains: [genomics, ml]
     domains: z.array(z.string()).default([]),
+    draft: z.boolean().default(false),
   }),
 });
 

--- a/src/content/webinars/en/aspects-of-high-throughput-molecular-data-analysis.md
+++ b/src/content/webinars/en/aspects-of-high-throughput-molecular-data-analysis.md
@@ -12,6 +12,7 @@ type: bioinfonet
 image: ""
 topic: ""
 keyTakeaways: []
+draft: true
 ---
 
 **Presenter**

--- a/src/content/webinars/en/computational-metagenomics-species-level.md
+++ b/src/content/webinars/en/computational-metagenomics-species-level.md
@@ -12,6 +12,7 @@ type: bioinfonet
 image: ""
 topic: ""
 keyTakeaways: []
+draft: true
 ---
 
 After Dr. Can's (METU, Ankara – Turkey) talk, our next guest was from Robert Koch Institute, Berlin, Germany. Dr. Bernhard Y Renard heads the bioinformatics research group at Robert Koch Institute, the German national institute for infectious disease in Berlin, Germany and is an adjunct senior lecturer (Privatdozent) at the department of mathematics and computer science at Freie Universität Berlin.

--- a/src/content/webinars/en/reconstruction-signaling-network-topology.md
+++ b/src/content/webinars/en/reconstruction-signaling-network-topology.md
@@ -12,6 +12,7 @@ type: bioinfonet
 image: ""
 topic: ""
 keyTakeaways: []
+draft: true
 ---
 
 The first webinar of BioInfoNet series was given by Dr. Tolga Can from METU (Middle East Technical University), Ankara, Turkey. METU is one of the oldest, biggest and best universities in Turkey. [Dr. Can](http://www.ceng.metu.edu.tr/~tcan/) has a bioinformatics lab. in the Computer Science Department.

--- a/src/content/webinars/tr/aspects-of-high-throughput-molecular-data-analysis.md
+++ b/src/content/webinars/tr/aspects-of-high-throughput-molecular-data-analysis.md
@@ -12,6 +12,7 @@ type: bioinfonet
 image: ""
 topic: ""
 keyTakeaways: []
+draft: true
 ---
 
 **Sunucu**

--- a/src/content/webinars/tr/computational-metagenomics-species-level.md
+++ b/src/content/webinars/tr/computational-metagenomics-species-level.md
@@ -12,6 +12,7 @@ type: bioinfonet
 image: ""
 topic: ""
 keyTakeaways: []
+draft: true
 ---
 
 **Sunucu**

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -3,7 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
 
 const blogPosts = await getCollection('blog', ({ id, data }) => id.startsWith('en/') && !data.draft);
-const webinars = await getCollection('webinars', ({ id }) => id.startsWith('en/'));
+const webinars = await getCollection('webinars', ({ id, data }) => id.startsWith('en/') && !data.draft);
 
 const searchIndex = [
   ...blogPosts.map(p => ({

--- a/src/pages/tr/search.astro
+++ b/src/pages/tr/search.astro
@@ -3,7 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
 
 const blogPosts = await getCollection('blog', ({ id, data }) => id.startsWith('tr/') && !data.draft);
-const webinars = await getCollection('webinars', ({ id }) => id.startsWith('tr/'));
+const webinars = await getCollection('webinars', ({ id, data }) => id.startsWith('tr/') && !data.draft);
 
 const searchIndex = [
   ...blogPosts.map(p => ({

--- a/src/pages/tr/webinars.astro
+++ b/src/pages/tr/webinars.astro
@@ -7,7 +7,7 @@ const lang = 'tr';
 const t = useTranslations(lang);
 const pageTitle = "Webinarlar - RSG Türkiye";
 
-const allWebinars = await getCollection('webinars');
+const allWebinars = await getCollection('webinars', ({ data }) => !data.draft);
 const trWebinars = allWebinars.filter(w => w.id.startsWith('tr/'));
 const sortedWebinars = trWebinars.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 

--- a/src/pages/tr/webinars/[slug].astro
+++ b/src/pages/tr/webinars/[slug].astro
@@ -3,7 +3,7 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
 import { getCollection, render } from 'astro:content';
 
 export async function getStaticPaths() {
-  const all = await getCollection('webinars');
+  const all = await getCollection('webinars', ({ data }) => !data.draft);
   const trWebinars = all.filter(w => w.id.startsWith('tr/'));
   const allIds = new Set(all.map(w => w.id));
   return trWebinars.map((webinar) => {

--- a/src/pages/webinars.astro
+++ b/src/pages/webinars.astro
@@ -7,7 +7,7 @@ const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
 const pageTitle = "Webinars - RSG Turkiye";
 
-const allWebinars = await getCollection('webinars');
+const allWebinars = await getCollection('webinars', ({ data }) => !data.draft);
 const enWebinars = allWebinars.filter(w => w.id.startsWith('en/'));
 const sortedWebinars = enWebinars.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 

--- a/src/pages/webinars/[slug].astro
+++ b/src/pages/webinars/[slug].astro
@@ -3,7 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getCollection, render } from 'astro:content';
 
 export async function getStaticPaths() {
-  const all = await getCollection('webinars');
+  const all = await getCollection('webinars', ({ data }) => !data.draft);
   const enWebinars = all.filter(w => w.id.startsWith('en/'));
   const allIds = new Set(all.map(w => w.id));
   return enWebinars.map((webinar) => {


### PR DESCRIPTION
Part of #3 (broken YouTube links). Audited all 11 unique youtubeUrl values across the webinar collection via YouTube's oEmbed endpoint. 9 are valid and match their topic. 2 are dead, affecting 3 posts:

- `aspects-of-high-throughput-molecular-data-analysis.md` (EN+TR) — dead video
- `computational-metagenomics-species-level.md` (EN+TR) — dead video
- `reconstruction-signaling-network-topology.md` (EN only) — frontmatter youtubeUrl was actually copy-pasted from the metagenomics post above; its own body text links a different ID, also dead

All three are 2014/2019-era BioInfoNet talks predating the current RSG-Turkiye YouTube channel. Searched for the correct recordings and couldn't find them anywhere. The BigMarker links these old posts also reference turned out to be stale event-archive pages (attendance stats, no actual recording) -- confirmed by fetching them, not just guessing from the URL.

Since a webinar without a recording isn't worth surfacing, drafted all 3 rather than link to nothing or something dead:
- Added `draft` to the webinars schema (previously only `blog` had this field)
- Excluded drafts from every page that queries the webinars collection: both listing pages, both detail-page `getStaticPaths`, both search pages

Verified: `npm run build` succeeds (249 pages, down from 254 -- exactly the 5 EN+TR detail pages for these 3 posts), `npx astro check` is clean, and the 3 posts no longer appear in listings or search in either language.