### PR TITLE
Fix grammar and punctuation in celebrating-the-bioinfonet-project.md

### DIFF
--- a/src/content/blog/en/celebrating-the-bioinfonet-project.md
+++ b/src/content/blog/en/celebrating-the-bioinfonet-project.md
@@ -10,14 +10,14 @@ lang: "en"
 draft: false
 ---
 
-I met ISCB RSG Turkiye guys in 2011 in the first student symposium which was held as a satellite meeting with HiBiT. I was working in a _de novo_ genome project and it was my first time talking about a serious project as a graduate student at a symposium. Many of you can picture my anxiety. But things got better immediately: I met colleagues from Turkey!
+I met the ISCB RSG Turkiye team in 2011 in the first student symposium which was held as a satellite meeting with HiBiT. I was working in a _de novo_ genome project and it was my first time presenting a serious project as a graduate student at a symposium. Many of you can picture my anxiety. But things got better immediately: I met colleagues from Turkey!
 
 Some of you may have difficulty understanding why it would be “that” important and pleasing to meet colleagues. Well…
 
-If you live and study in a developing country and you are, almost, trying to study in a new research area, here’s your life’s new soundtrack: “All by myself”. Every single living thing in life needs a proper environment to become something. So, like a plant needs soil, water and light, becoming a scientist requires scientific environment.
+If you live and study in a developing country and you are, almost, trying to study in a new research area, here’s your life’s new soundtrack: “All by myself”. Every single living thing in life needs a proper environment to become something. So, like a plant needs soil, water and light, becoming a scientist requires a scientific environment.
 
-So, as a living organism, I made colleague-taxis and became a part of the group. Then we found out that we needed another taxis movement towards real scientific talk. With this need, BioInfoNet Project was born. We wrote a proposal to the ISCB (International Society for Computational Biology) Student Council. They kindly supported us and here we are.
+So, as a living organism, I made connections and became a part of the group. Then we found out that we needed another  movement towards real scientific talk. With this need, BioInfoNet Project was born. We wrote a proposal to the ISCB (International Society for Computational Biology) Student Council. They kindly supported us and here we are.
 
-Today, as a student group, we have reach to roughly 250 people all around the world (and it is increasing). We have completed two beautiful [webinars](https://www.bigmarker.com/communities/bioinfonet/conferences) given by top notch researchers, which we were really pleased to participate. We are planning ahead for a student symposium and many more webinars.
+Today, as a student group, we have reached roughly 250 people all around the world (and the number is increasing). We have completed two successful [webinars](https://www.bigmarker.com/communities/bioinfonet/conferences) given by top-notch researchers, which we were really pleased to participate in. We are planning ahead for a student symposium and many more webinars.
 
-We will make new taxis movements whenever needed. Join us. [Communities are good](http://www.bigmarker.com/bioinfonet) :o)
+We will make new movements whenever needed. Join us. [Communities are good](http://www.bigmarker.com/bioinfonet) :o)

--- a/src/content/blog/en/celebrating-the-bioinfonet-project.md
+++ b/src/content/blog/en/celebrating-the-bioinfonet-project.md
@@ -16,7 +16,7 @@ Some of you may have difficulty understanding why it would be “that” importa
 
 If you live and study in a developing country and you are, almost, trying to study in a new research area, here’s your life’s new soundtrack: “All by myself”. Every single living thing in life needs a proper environment to become something. So, like a plant needs soil, water and light, becoming a scientist requires a scientific environment.
 
-So, as a living organism, I made connections and became a part of the group. Then we found out that we needed another  movement towards real scientific talk. With this need, BioInfoNet Project was born. We wrote a proposal to the ISCB (International Society for Computational Biology) Student Council. They kindly supported us and here we are.
+So, as a living organism, I made connections and became a part of the group. Then we found out that we needed another movement towards real scientific talk. With this need, BioInfoNet Project was born. We wrote a proposal to the ISCB (International Society for Computational Biology) Student Council. They kindly supported us and here we are.
 
 Today, as a student group, we have reached roughly 250 people all around the world (and the number is increasing). We have completed two successful [webinars](https://www.bigmarker.com/communities/bioinfonet/conferences) given by top-notch researchers, which we were really pleased to participate in. We are planning ahead for a student symposium and many more webinars.
 


### PR DESCRIPTION
Continues #13 by @piyushsable62-ops — carries their grammar/wording fixes forward (their fork was deleted, so this reopens the change on a fresh branch) plus one small follow-up: a leftover double space introduced by the original edit ("another  movement" → "another movement").

Original contribution and fixes:
- "the ISCB RSG Turkiye guys" → "the ISCB RSG Turkiye team"
- "talking about" → "presenting"
- "scientific environment" → "a scientific environment"
- "colleague-taxis" → "connections" / "taxis movement" → "movement" (typo fixed here)
- "we have reach to" → "we have reached"
- "top notch" → "top-notch", "participate" → "participate in"

Closes #13.