### PR TITLE
Fix and fill in webinar YouTube links (#3)

### DIFF
--- a/src/content/webinars/en/accessing-multi-omics-data-tumour-profiling-aashil-batavia.md
+++ b/src/content/webinars/en/accessing-multi-omics-data-tumour-profiling-aashil-batavia.md
@@ -5,7 +5,7 @@ speaker: Aashil A. Batavia
 speakerAffiliation: Institute of Pathology and Molecular Pathology, USZ / ETH Zurich
 speakerTitle: PhD Researcher
 description: An introduction to accessing The Cancer Genome Atlas repository and tools for multi-omics assessment of tumours, focusing on renal cell carcinomas.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=rr5bhWKIR_I"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/en/aspects-of-high-throughput-molecular-data-analysis.md
+++ b/src/content/webinars/en/aspects-of-high-throughput-molecular-data-analysis.md
@@ -6,14 +6,13 @@ speakerAffiliation: ""
 speakerTitle: ""
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787436584/rsgturkey/webinars/arif-harmanci.jpg"
 description: An overview of how genomics, transcriptomics, and epigenetics are changing our understanding of molecular health, and the future challenges of high-throughput data analysis.
-youtubeUrl: "https://www.youtube.com/watch?v=byv0BT9shwA"
+youtubeUrl: "https://www.youtube.com/watch?v=AxqdPMEUfyg"
 slidesUrl: ""
 year: 2019
 type: bioinfonet
 image: ""
 topic: ""
 keyTakeaways: []
-draft: true
 ---
 
 **Presenter**

--- a/src/content/webinars/en/big-data-in-life-sciences-nikolay-oskolkov.md
+++ b/src/content/webinars/en/big-data-in-life-sciences-nikolay-oskolkov.md
@@ -6,7 +6,7 @@ speakerAffiliation: SciLifeLab / Lund University
 speakerTitle: Bioinformatician
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437497/rsgturkey/webinars/nikolay-oskolkov-v2.jpg"
 description: An overview of applications of Artificial Neural Networks to Single Cell Genomics, Microscopy Imaging, and Genomics/Ancient DNA research, addressing the challenges of big data in life sciences.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=t38ciyb42vY"
 slidesUrl: ""
 year: 2019
 type: bioinfonet

--- a/src/content/webinars/en/cen-tools-integrative-platform-essential-genes.md
+++ b/src/content/webinars/en/cen-tools-integrative-platform-essential-genes.md
@@ -6,7 +6,7 @@ speakerAffiliation: ""
 speakerTitle: ""
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787436697/rsgturkey/webinars/cansu-dincer.jpg"
 description: Presentation of CEN-tools, a website and Python package for interrogating gene essentiality from large-scale CRISPR screens across biological contexts including tissue of origin, mutation profiles, and drug response levels.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=xhp6-yzRkPs"
 slidesUrl: ""
 year: 2021
 type: bioinfonet

--- a/src/content/webinars/en/comparison-sars-cov-2-variants-insaflu-galaxyproject.md
+++ b/src/content/webinars/en/comparison-sars-cov-2-variants-insaflu-galaxyproject.md
@@ -5,7 +5,7 @@ speaker: "Nazlı S. Kara, Meltem Kutnu, Yasemin Utkueri, Funda Yılmaz, Elif Boz
 speakerAffiliation: "İstinye University / METU / Sabancı University / Radboud University / University of Veterinary Medicine Vienna / University of Arizona"
 speakerTitle: ""
 description: A comparative study of SARS-CoV-2 genome variants identified by the Galaxy Project and INSaFLU workflows, presented by RSG-Turkey active members.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=jZCzRShkFTM"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/en/density-based-clustering-metabarcodes-nanopore.md
+++ b/src/content/webinars/en/density-based-clustering-metabarcodes-nanopore.md
@@ -6,7 +6,7 @@ speakerAffiliation: Centre for Biodiversity Genomics, University of Guelph
 speakerTitle: Postdoctoral Researcher
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787436909/rsgturkey/webinars/bilgenur-baloglu.jpg"
 description: Presentation of a new Python pipeline (ASHURE) for density-based clustering and error correction of metabarcodes using Oxford Nanopore sequencing, achieving >99% sequence accuracy for freshwater mock communities.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=9s66xlGB7BM"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/en/drivers-of-genetic-diversity-kimberly-gilbert.md
+++ b/src/content/webinars/en/drivers-of-genetic-diversity-kimberly-gilbert.md
@@ -6,7 +6,7 @@ speakerAffiliation: University of Lausanne
 speakerTitle: Postdoctoral Fellow
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437499/rsgturkey/webinars/kimberly-gilbert-v2.jpg"
 description: A theoretical and empirical study of how multi-locus associative overdominance can amplify genetic diversity in low-recombination regions, with evidence of this phenomenon in the human genome.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=bz6RzlWpDns"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/en/early-detection-skin-cancer-deep-learning-vidit-go.md
+++ b/src/content/webinars/en/early-detection-skin-cancer-deep-learning-vidit-go.md
@@ -5,7 +5,7 @@ speaker: Vidit Goyal
 speakerAffiliation: Dr. A.P.J Abdul Kalam Technical University
 speakerTitle: ""
 description: A convolutional neural network approach using Modified Inception and MobileNet models to detect and classify skin cancer types, evaluated on the HAM10000 dataset.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=505_aaVEpXw"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/en/first-webinar-2018-integrative-modeling.md
+++ b/src/content/webinars/en/first-webinar-2018-integrative-modeling.md
@@ -13,6 +13,7 @@ type: bioinfonet
 image: ""
 topic: ""
 keyTakeaways: []
+draft: true
 ---
 
 We are very excited to revive our webinar series again! The first webinar of this year was given by Assoc. Prof. Ezgi Karaca from Izmir Biomedicine and Genome Center on January 31st. She mentioned about the main techniques in structural biology, data types and how integrate the experimental structural biology data into biomolecular simulations. In particular, she raised our curiosity in computational structural biology by mentioning about "docking" program HADDOCK, and her latest work on "integrative modeling" which was published on Nature Methods. Around 100 people registered our webinar. Our aim is to increase this number and reach more people in soon!

--- a/src/content/webinars/en/impact-protein-structure-sequence-evolution-dutheil.md
+++ b/src/content/webinars/en/impact-protein-structure-sequence-evolution-dutheil.md
@@ -5,7 +5,7 @@ speaker: Julien Y. Dutheil
 speakerAffiliation: Max Planck Institute for Evolutionary Biology
 speakerTitle: ""
 description: Investigation of how protein structure influences sequence evolution, focusing on the distribution of adaptive mutations along 3D protein structures and coevolution between positions.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=VBBZS5xLjec"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/en/lewontin-paradox-ergi-deniz-ozsoy.md
+++ b/src/content/webinars/en/lewontin-paradox-ergi-deniz-ozsoy.md
@@ -6,7 +6,7 @@ speakerAffiliation: Hacettepe University
 speakerTitle: ""
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437183/rsgturkey/webinars/ergi-deniz-ozsoy.jpg"
 description: A summary of modern studies and approaches related to the Lewontin Paradox — the contradiction between population size and neutral genetic variation — with emphasis on the Hill-Robertson effect and linked selection.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=oTwkgbuFaX0"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/en/minimizer-space-de-bruijn-graphs.md
+++ b/src/content/webinars/en/minimizer-space-de-bruijn-graphs.md
@@ -5,7 +5,7 @@ speaker: "Barış Ekim"
 speakerAffiliation: "Massachusetts Institute of Technology"
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437262/rsgturkey/webinars/baris-ekim.jpg"
 description: "Barış Ekim introduces minimizer-space sequencing data analysis (mdBG), achieving orders-of-magnitude improvements in genome assembly speed and memory usage over existing methods."
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=_IDr-TbAHv8"
 slidesUrl: ""
 year: 2021
 type: "bioinfonet"

--- a/src/content/webinars/en/molecular-simulations.md
+++ b/src/content/webinars/en/molecular-simulations.md
@@ -6,7 +6,7 @@ speakerAffiliation: Izmir Biomedicine and Genome Center
 speakerTitle: Research Group Leader
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437299/rsgturkey/webinars/seyit-kale.jpg"
 description: A historical and physical perspective on how molecular simulations can be thought of as in silico experiments, exploring the analogy between simulation and wet-lab experiments in structural biology.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=Nc3uD6b8zP0"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/en/open-student-webinars-gebze-technical-university.md
+++ b/src/content/webinars/en/open-student-webinars-gebze-technical-university.md
@@ -4,7 +4,7 @@ date: 2022-04-08
 speaker: "Dilara Uzuner, Ecehan Abdik, Hatice Büşra Lüleci, Müberra Fatma Cesur"
 speakerAffiliation: "Gebze Technical University"
 description: "Four graduate students from Gebze Technical University present their research in cancer dormancy, Parkinson's disease metabolism, Alzheimer's disease, and Klebsiella pneumoniae drug targets."
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=E2th8MhiaZE"
 slidesUrl: ""
 year: 2022
 type: "student"

--- a/src/content/webinars/en/palaeogenomic-investigation-northeast-asia.md
+++ b/src/content/webinars/en/palaeogenomic-investigation-northeast-asia.md
@@ -6,7 +6,7 @@ speakerAffiliation: Stockholm University
 speakerTitle: Postdoctoral Researcher
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437335/rsgturkey/webinars/gulsah-merve-kilinc.png"
 description: Ancient DNA analysis of 40 individuals spanning 17,000–550 years from Yakutia and Lake Baikal, revealing gene flow events, Palaeo-Inuit ancestors, and Yersinia pestis in ancient Northeast Asia.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=tZY_m1_C8s8"
 slidesUrl: ""
 year: 2021
 type: bioinfonet

--- a/src/content/webinars/en/phylogenetic-analysis-sars-cov-2-turkey-aylin-bircan.md
+++ b/src/content/webinars/en/phylogenetic-analysis-sars-cov-2-turkey-aylin-bircan.md
@@ -5,7 +5,7 @@ speaker: Aylin Bircan
 speakerAffiliation: Sabanci University
 speakerTitle: PhD Student
 description: A comprehensive phylogenetic analysis of SARS-CoV-2 genomes in Turkey using 15,277 global sequences, revealing early introduction of the virus and multiple independent international transmission events.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=8lz2Dl49bIs"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/en/projecting-covid-19-turkey-probabilistic-modeling.md
+++ b/src/content/webinars/en/projecting-covid-19-turkey-probabilistic-modeling.md
@@ -6,7 +6,7 @@ speakerAffiliation: METU Informatics Institute
 speakerTitle: Research Assistant
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437699/rsgturkey/webinars/huseyin-cahit-burduroglu.png"
 description: A Bayesian negative binomial multilevel model with mixed effects for projecting COVID-19 confirmed daily and cumulative cases in Turkey, showing a decreasing epidemic curve under compliance with containment measures.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=vaGt4LfpPPY"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/en/role-of-cholinergic-signals-in-cancer-biology.md
+++ b/src/content/webinars/en/role-of-cholinergic-signals-in-cancer-biology.md
@@ -6,7 +6,7 @@ speakerAffiliation: Bilkent University
 speakerTitle: Associate Professor
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437847/rsgturkey/webinars/ozlen-konu.jpg"
 description: An in silico, in vitro, and in vivo investigation of cholinergic signals in cancer progression, including the role of CHRNA5 in breast cancer and zebrafish xenograft models for liver cancer.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=bmi9kpz6H2Y"
 slidesUrl: ""
 year: 2021
 type: bioinfonet

--- a/src/content/webinars/en/species-specific-allosteric-drug-design.md
+++ b/src/content/webinars/en/species-specific-allosteric-drug-design.md
@@ -5,7 +5,7 @@ speaker: "Reyhan Metin / Metehan Çelebi"
 speakerAffiliation: ""
 speakerTitle: ""
 description: A study using Constraint Molecular Dynamics simulation to clarify how glycolytic enzymes are allosterically inhibited in a species-specific manner, enabling targeted drug design.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=8_c8dQFNqlI"
 slidesUrl: ""
 year: 2021
 type: bioinfonet

--- a/src/content/webinars/en/understanding-viral-diversity-dynamics.md
+++ b/src/content/webinars/en/understanding-viral-diversity-dynamics.md
@@ -6,7 +6,7 @@ speakerAffiliation: University of Perdana / Bezmialem Vakıf University
 speakerTitle: Associate Professor
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787438111/rsgturkey/webinars/mohammad-asif-khan.jpg"
 description: An exploration of viral diversity dynamics at the protein sequence level, focusing on how viruses evade host immune responses through rapid mutation and the implications for vaccine design.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=dgFkmhO0hB4"
 slidesUrl: ""
 year: 2021
 type: bioinfonet

--- a/src/content/webinars/tr/accessing-multi-omics-data-tumour-profiling-aashil-batavia.md
+++ b/src/content/webinars/tr/accessing-multi-omics-data-tumour-profiling-aashil-batavia.md
@@ -5,7 +5,7 @@ speaker: Aashil A. Batavia
 speakerAffiliation: USZ Patoloji ve Moleküler Patoloji Enstitüsü / ETH Zurich
 speakerTitle: Doktora Araştırmacısı
 description: TCGA deposuna erişim yolları ve renal hücre karsinomlarının çoklu omik değerlendirmesi için kullanılan araçların tanıtımı.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=rr5bhWKIR_I"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/tr/aspects-of-high-throughput-molecular-data-analysis.md
+++ b/src/content/webinars/tr/aspects-of-high-throughput-molecular-data-analysis.md
@@ -6,14 +6,13 @@ speakerAffiliation: ""
 speakerTitle: ""
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787436584/rsgturkey/webinars/arif-harmanci.jpg"
 description: Genomiğin, transkriptomiğin ve epigenetiğin bireysel sağlığa nasıl yansıdığını anlama biçimimizi nasıl değiştirdiğine dair farklı boyutların gözden geçirilmesi ve yüksek verimli veri analizinin gelecekteki zorlukları.
-youtubeUrl: "https://www.youtube.com/watch?v=byv0BT9shwA"
+youtubeUrl: "https://www.youtube.com/watch?v=AxqdPMEUfyg"
 slidesUrl: ""
 year: 2019
 type: bioinfonet
 image: ""
 topic: ""
 keyTakeaways: []
-draft: true
 ---
 
 **Sunucu**

--- a/src/content/webinars/tr/big-data-in-life-sciences-nikolay-oskolkov.md
+++ b/src/content/webinars/tr/big-data-in-life-sciences-nikolay-oskolkov.md
@@ -6,7 +6,7 @@ speakerAffiliation: SciLifeLab / Lund Üniversitesi
 speakerTitle: Biyoinformatikçi
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437497/rsgturkey/webinars/nikolay-oskolkov-v2.jpg"
 description: Yapay Sinir Ağları'nın Tek Hücre Genomiği, Mikroskopi Görüntüleme ve Genomik/Antik DNA araştırma alanlarına uygulamalarına genel bakış; yaşam bilimlerinde büyük verinin zorluklarını ele alıyor.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=t38ciyb42vY"
 slidesUrl: ""
 year: 2019
 type: bioinfonet

--- a/src/content/webinars/tr/cen-tools-integrative-platform-essential-genes.md
+++ b/src/content/webinars/tr/cen-tools-integrative-platform-essential-genes.md
@@ -6,7 +6,7 @@ speakerAffiliation: ""
 speakerTitle: ""
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787436697/rsgturkey/webinars/cansu-dincer.jpg"
 description: "CEN-tools sunum: büyük ölçekli CRISPR taramalarından gen esansiyalitesini doku tipi, mutasyon profilleri ve ilaç yanıt seviyeleri gibi biyolojik bağlamlarda sorgulayan web sitesi ve Python paketi."
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=xhp6-yzRkPs"
 slidesUrl: ""
 year: 2021
 type: bioinfonet

--- a/src/content/webinars/tr/comparison-sars-cov-2-variants-insaflu-galaxyproject.md
+++ b/src/content/webinars/tr/comparison-sars-cov-2-variants-insaflu-galaxyproject.md
@@ -5,7 +5,7 @@ speaker: "Nazlı S. Kara, Meltem Kutnu, Yasemin Utkueri, Funda Yılmaz, Elif Boz
 speakerAffiliation: "İstinye Üniversitesi / ODTÜ / Sabancı Üniversitesi / Radboud Üniversitesi / Viyana Veteriner Tıbbı Üniversitesi / Arizona Üniversitesi"
 speakerTitle: ""
 description: "RSG-Türkiye aktif üyeleri tarafından yürütülen çalışma: Galaxy Project ve INSaFLU iş akışları tarafından tanımlanan SARS-CoV-2 genomik varyantlarının karşılaştırmalı analizi."
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=jZCzRShkFTM"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/tr/density-based-clustering-metabarcodes-nanopore.md
+++ b/src/content/webinars/tr/density-based-clustering-metabarcodes-nanopore.md
@@ -6,7 +6,7 @@ speakerAffiliation: Biyoçeşitlilik Genomiği Merkezi, Guelph Üniversitesi
 speakerTitle: Doktora Sonrası Araştırmacı
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787436909/rsgturkey/webinars/bilgenur-baloglu.jpg"
 description: Oxford Nanopore MinION ve döngüsel daire amplifikasyon protokolü kullanılarak tatlı su sahte topluluğunun %99'dan fazla dizi doğruluğuyla değerlendirildiği ASHURE Python pipeline'ı.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=9s66xlGB7BM"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/tr/drivers-of-genetic-diversity-kimberly-gilbert.md
+++ b/src/content/webinars/tr/drivers-of-genetic-diversity-kimberly-gilbert.md
@@ -6,7 +6,7 @@ speakerAffiliation: Lozan Üniversitesi
 speakerTitle: Doktora Sonrası Araştırmacı
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437499/rsgturkey/webinars/kimberly-gilbert-v2.jpg"
 description: Çok lokuslu ilişkisel üstünlüğün (AOD) düşük rekombinasyon bölgelerindeki genetik çeşitliliği nasıl artırabileceğine dair teorik ve ampirik bir çalışma; insan genomunda 22 bu tür bölge tespit edilmiştir.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=bz6RzlWpDns"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/tr/early-detection-skin-cancer-deep-learning-vidit-go.md
+++ b/src/content/webinars/tr/early-detection-skin-cancer-deep-learning-vidit-go.md
@@ -5,7 +5,7 @@ speaker: Vidit Goyal
 speakerAffiliation: Dr. A.P.J Abdul Kalam Teknik Üniversitesi
 speakerTitle: ""
 description: HAM10000 veri seti kullanılarak Melanoma, Dermatofibroma ve Benign Keratoz lezyonlarını tespit eden ve sınıflandıran Modifiye Inception ve MobileNet CNN modelleri ile cilt kanseri erken tespiti.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=505_aaVEpXw"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/tr/haddock-biomolecular-complex-modeling-bonvin.md
+++ b/src/content/webinars/tr/haddock-biomolecular-complex-modeling-bonvin.md
@@ -6,7 +6,7 @@ speakerAffiliation: Utrecht Üniversitesi / Bijvoet Biyomoleküler Araştırma M
 speakerTitle: Profesör
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437097/rsgturkey/webinars/alexandre-bonvin.jpg"
 description: "HADDOCK yazılımı etrafındaki son gelişmelerin vurgulandığı konuşma: biyomoleküler kompleks yapı tahmininde bütünleştirici modellemenin önemi ve yalnızca dizilimden antikor-antijen etkileşimlerinin modellenmesi."
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=dHbW0cRX5gA"
 slidesUrl: ""
 year: 2024
 type: bioinfonet

--- a/src/content/webinars/tr/impact-protein-structure-sequence-evolution-dutheil.md
+++ b/src/content/webinars/tr/impact-protein-structure-sequence-evolution-dutheil.md
@@ -5,7 +5,7 @@ speaker: Julien Y. Dutheil
 speakerAffiliation: Max Planck Evrimsel Biyoloji Enstitüsü
 speakerTitle: ""
 description: Protein yapısının sekans evrimi üzerindeki etkisinin araştırılması; 3D protein yapıları boyunca adaptif mutasyonların dağılımı ve pozisyonlar arasındaki eş-evrim.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=VBBZS5xLjec"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/tr/lewontin-paradox-ergi-deniz-ozsoy.md
+++ b/src/content/webinars/tr/lewontin-paradox-ergi-deniz-ozsoy.md
@@ -6,7 +6,7 @@ speakerAffiliation: Hacettepe Üniversitesi
 speakerTitle: ""
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437183/rsgturkey/webinars/ergi-deniz-ozsoy.jpg"
 description: Lewontin Paradoksu'nun çözümüne işaret eden modern çalışmaların ve yaklaşımların özeti; klasik Hill-Robertson etkisi bağlamında "bağlantılı seçilim" sürecine vurgu yapılarak.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=oTwkgbuFaX0"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/tr/minimizer-space-de-bruijn-graphs.md
+++ b/src/content/webinars/tr/minimizer-space-de-bruijn-graphs.md
@@ -5,7 +5,7 @@ speaker: "Barış Ekim"
 speakerAffiliation: "Massachusetts Institute of Technology"
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437262/rsgturkey/webinars/baris-ekim.jpg"
 description: "Barış Ekim, minimizer-uzay dizileme veri analizini (mdBG) tanıtıyor: mevcut yöntemlere kıyasla genom birleştirmede hız ve bellek kullanımında büyük ölçüde iyileşme sağlayan yeni bir yaklaşım."
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=_IDr-TbAHv8"
 slidesUrl: ""
 year: 2021
 type: "bioinfonet"

--- a/src/content/webinars/tr/palaeogenomic-investigation-northeast-asia.md
+++ b/src/content/webinars/tr/palaeogenomic-investigation-northeast-asia.md
@@ -6,7 +6,7 @@ speakerAffiliation: Stockholm Üniversitesi
 speakerTitle: Doktora Sonrası Araştırmacı
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437335/rsgturkey/webinars/gulsah-merve-kilinc.png"
 description: Yakutya ve Baykal Gölü'nden 40 eski birey üzerinde yapılan antik DNA analizi; Paleolitik'ten Demir Çağı'na uzanan gen akışı olayları, Palaeo-Inuit ataları ve Yersinia pestis bulguları.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=tZY_m1_C8s8"
 slidesUrl: ""
 year: 2021
 type: bioinfonet

--- a/src/content/webinars/tr/phylogenetic-analysis-sars-cov-2-turkey-aylin-bircan.md
+++ b/src/content/webinars/tr/phylogenetic-analysis-sars-cov-2-turkey-aylin-bircan.md
@@ -5,7 +5,7 @@ speaker: Aylin Bircan
 speakerAffiliation: Sabancı Üniversitesi
 speakerTitle: Doktora Öğrencisi
 description: 15.277 global SARS-CoV-2 genomu ile Türkiye'deki viral izolatların filogenetik analizi; virüsün raporlanan ilk vakadan önce ülkeye girdiğini ve çoklu bağımsız uluslararası giriş yollarını ortaya koyuyor.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=8lz2Dl49bIs"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/tr/projecting-covid-19-turkey-probabilistic-modeling.md
+++ b/src/content/webinars/tr/projecting-covid-19-turkey-probabilistic-modeling.md
@@ -6,7 +6,7 @@ speakerAffiliation: ODTÜ Bilişim Enstitüsü
 speakerTitle: Araştırma Asistanı
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437699/rsgturkey/webinars/huseyin-cahit-burduroglu.png"
 description: Türkiye'deki COVID-19 pandemisinin projeksiyonu için Bayesci negatif binom çok düzeyli model; önlemlere uyum devam ettiğinde salgın eğrisinin azaldığını gösteriyor.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=vaGt4LfpPPY"
 slidesUrl: ""
 year: 2020
 type: bioinfonet

--- a/src/content/webinars/tr/role-of-cholinergic-signals-in-cancer-biology.md
+++ b/src/content/webinars/tr/role-of-cholinergic-signals-in-cancer-biology.md
@@ -6,7 +6,7 @@ speakerAffiliation: Bilkent Üniversitesi
 speakerTitle: Doçent
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787437847/rsgturkey/webinars/ozlen-konu.jpg"
 description: Kolinerjik sinyallerin kanser ilerlemesindeki rolüne dair in silico, in vitro ve in vivo bulgular; meme kanserinde CHRNA5'in rolü ve karaciğer kanseri için zebra balığı ksenograft modelleri.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=bmi9kpz6H2Y"
 slidesUrl: ""
 year: 2021
 type: bioinfonet

--- a/src/content/webinars/tr/species-specific-allosteric-drug-design.md
+++ b/src/content/webinars/tr/species-specific-allosteric-drug-design.md
@@ -5,7 +5,7 @@ speaker: "Reyhan Metin / Metehan Çelebi"
 speakerAffiliation: ""
 speakerTitle: ""
 description: Glikolitik enzimlerin allosterik inhibisyonunu çeşitli analiz yöntemleriyle açıklamak için Kısıtlı Moleküler Dinamik simülasyon yönteminin kullanımı.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=8_c8dQFNqlI"
 slidesUrl: ""
 year: 2021
 type: bioinfonet

--- a/src/content/webinars/tr/understanding-viral-diversity-dynamics.md
+++ b/src/content/webinars/tr/understanding-viral-diversity-dynamics.md
@@ -6,7 +6,7 @@ speakerAffiliation: Perdana Üniversitesi / Bezmialem Vakıf Üniversitesi
 speakerTitle: Doçent
 speakerPhoto: "https://res.cloudinary.com/dyuf14ra5/image/upload/f_auto,q_auto,w_600/v1787438111/rsgturkey/webinars/mohammad-asif-khan.jpg"
 description: Protein dizisi düzeyinde viral çeşitlilik dinamikleri ve virüslerin konakçı bağışıklık tepkisinden kaçma mekanizmaları; aşı tasarımına yönelik çıkarımlar.
-youtubeUrl: ""
+youtubeUrl: "https://www.youtube.com/watch?v=dgFkmhO0hB4"
 slidesUrl: ""
 year: 2021
 type: bioinfonet


### PR DESCRIPTION
Closes part of #3 (YouTube link portion).

Cross-referenced every webinar against RSG-Türkiye's actual YouTube channel (@RSG-Turkiye, 72 videos total — pulled via yt-dlp since the channel's public RSS feed only exposes the latest 15). Every added/changed link below is an exact title match, and every video ID was confirmed live via YouTube's oembed endpoint before use.

**Added real links (18 webinars, were empty):** Aashil Batavia, Nikolay Oskolkov, CEN tools, SARS-CoV-2 variants comparison, Bilgenur Baloğlu, Kimberly Gilbert, Vidit Goyal, Julien Dutheil, Barış Ekim, Seyit Kale, Gebze student webinars, Gülşah Merve Kılınç, Aylin Bircan, Hüseyin Cahit Burduroğlu, Özlen Konu, allosteric drug design, Mohammad Asif Khan, Ergi Deniz Özsoy. Also added the real link for the Bonvin webinar split off in #27.

**Fixed a wrongly-drafted one:** "Aspects of High Throughput Molecular Data Analysis" (Arif Harmancı) was marked `draft: true` because its `youtubeUrl` (`byv0BT9shwA`) 404s — but the actual recording is on the channel under a different ID (`AxqdPMEUfyg`, exact title match, confirmed live). Fixed the ID and removed the draft flag.

**Found and flagged a duplicate:** `first-webinar-2018-integrative-modeling.md` and `integrative-modeling-of-biomolecular-complexes.md` are the same talk (Ezgi Karaca, HADDOCK, Jan 2018) entered twice — one as a blog-style recap, one as the structured webinar page with the real working link. Marked the recap duplicate as `draft: true` rather than deleting it, in case the write-up itself is worth keeping elsewhere.

**Confirmed still genuinely unavailable (left unchanged):**
- Yaron Orenstein, David Žihala, Serbulent Unsal, Ömer Ali Bayraktar, Hatice Ülkü Osmanbeyoğlu, Begüm Serra Büyüktarakçı, Dr. Ayesha Fatima, and the generic "Open Student Webinars" entry — not found on the channel under any matching title.
- The two already-drafted dead-link webinars (Bernhard Renard, Tolga Can) — re-checked against the full 72-video list, still not there. Tolga Can's original 2014 talk (RSG-Türkiye's very first webinar) appears to have been removed from the channel entirely; even the old blog post's own embedded backup link (`youtu.be/pPxowfg4Hhs`) 404s.

Verified with a full local build (250 pages, no errors).