### PR TITLE
Fix broken webinar links in Learning Paths resource cards

### DIFF
--- a/src/content/lp-levels/en/metagenomics-explorer.md
+++ b/src/content/lp-levels/en/metagenomics-explorer.md
@@ -30,11 +30,4 @@ sections:
         description: "QIIME2's introductory tutorial uses time-series data from a real study. Follow it end-to-end using their test data — you'll see the full 16S workflow before applying it to your own samples."
         tag: Tutorial
         url: "https://docs.qiime2.org/2024.10/tutorials/moving-pictures/"
-
-  - type: webinars
-    resources:
-      - title: "Computational Metagenomics at the Species Level"
-        description: "A foundational talk on the computational challenges of metagenomic analysis — taxonomic profiling, assembly, and the assumptions behind each approach. A good conceptual grounding before touching tools."
-        tag: Webinar
-        webinarSlug: computational-metagenomics-species-level
 ---

--- a/src/content/lp-levels/en/ml-specialist.md
+++ b/src/content/lp-levels/en/ml-specialist.md
@@ -39,10 +39,6 @@ sections:
 
   - type: webinars
     resources:
-      - title: "Reconstruction of Signaling Network Topology"
-        description: "ML-based network inference applied to signalling biology. A technically dense talk that demonstrates how graph-based models handle biological network data."
-        tag: Webinar
-        webinarSlug: reconstruction-signaling-network-topology
       - title: "CEN Tools — Integrative Platform for Essential Genes"
         description: "Multi-omics integration for essentiality prediction. Relevant if you work on target identification, CRISPR screen analysis, or multi-modal data fusion."
         tag: Webinar

--- a/src/content/lp-levels/en/structural-explorer.md
+++ b/src/content/lp-levels/en/structural-explorer.md
@@ -40,5 +40,5 @@ sections:
       - title: "Integrative Modeling of Biomolecular Complexes (2018)"
         description: "The first RSG Turkey webinar on structural biology. Covers the big questions: how do we model large assemblies that can't be crystallised? A good orientation to the field's scope."
         tag: Webinar
-        webinarSlug: first-webinar-2018-integrative-modeling
+        webinarSlug: integrative-modeling-of-biomolecular-complexes
 ---

--- a/src/content/lp-levels/tr/metagenomics-explorer.md
+++ b/src/content/lp-levels/tr/metagenomics-explorer.md
@@ -30,11 +30,4 @@ sections:
         description: "QIIME2'nin tanıtım eğitimi, gerçek bir çalışmadan zaman serisi verisi kullanıyor. Test verileriyle uçtan uca takip edin — kendi örneklerinize uygulamadan önce tam 16S iş akışını göreceksiniz."
         tag: Tutorial
         url: "https://docs.qiime2.org/2024.10/tutorials/moving-pictures/"
-
-  - type: webinars
-    resources:
-      - title: "Computational Metagenomics at the Species Level"
-        description: "Metagenomik analizin hesaplamalı zorlukları üzerine temel bir konuşma — taksonomik profilleme, montaj ve her yaklaşımın arkasındaki varsayımlar. Araçlara dokunmadan önce iyi bir kavramsal zemin."
-        tag: Webinar
-        webinarSlug: computational-metagenomics-species-level
 ---

--- a/src/content/lp-levels/tr/ml-specialist.md
+++ b/src/content/lp-levels/tr/ml-specialist.md
@@ -39,10 +39,6 @@ sections:
 
   - type: webinars
     resources:
-      - title: "Reconstruction of Signaling Network Topology"
-        description: "Sinyal biyolojisine uygulanan ML tabanlı ağ çıkarımı. Graf tabanlı modellerin biyolojik ağ verisini nasıl işlediğini gösteren teknik yoğun bir konuşma."
-        tag: Webinar
-        webinarSlug: reconstruction-signaling-network-topology
       - title: "CEN Tools — Integrative Platform for Essential Genes"
         description: "Esansiyallik tahmini için çok-omik entegrasyonu. Hedef belirleme, CRISPR ekranı analizi veya çok-modal veri füzyonu üzerinde çalışıyorsanız ilgili."
         tag: Webinar

--- a/src/content/lp-levels/tr/structural-explorer.md
+++ b/src/content/lp-levels/tr/structural-explorer.md
@@ -40,5 +40,5 @@ sections:
       - title: "Integrative Modeling of Biomolecular Complexes (2018)"
         description: "Yapısal biyoloji üzerine ilk RSG Türkiye webinarı. Büyük soruları kapsıyor: kristalize edilemeyen büyük kompleksleri nasıl modelleriz? Alanın kapsamına iyi bir yönlendirme."
         tag: Webinar
-        webinarSlug: first-webinar-2018-integrative-modeling
+        webinarSlug: integrative-modeling-of-biomolecular-complexes
 ---


### PR DESCRIPTION
While auditing the site for other problems: \`ResourceCard.astro\` builds a hard link to \`/webinars/<webinarSlug>\` with no check on whether that webinar is actually published, so a reference to a \`draft: true\` webinar 404s. Found 3 such cases:

- **structural-explorer**: repointed "Integrative Modeling of Biomolecular Complexes (2018)" from the drafted duplicate (\`first-webinar-2018-integrative-modeling\`) to the real, non-drafted entry with the same content and a working video (\`integrative-modeling-of-biomolecular-complexes\`).
- **ml-specialist**: removed "Reconstruction of Signaling Network Topology" (Tolga Can, 2014) — confirmed in #29 that no recording exists anywhere for this talk.
- **metagenomics-explorer**: removed "Computational Metagenomics at the Species Level" (Bernhard Renard, 2014) — same, no recording exists. This was the only resource in that level's "webinars" section, so removed the whole section rather than leave an empty one.

All three fixed in both en/ and tr/. Re-verified every \`webinarSlug\` reference across \`lp-levels\` against the current draft status of every webinar — no other broken references remain.

Verified with a full local build (249 pages, no errors).